### PR TITLE
Fix turn counter

### DIFF
--- a/game.z80
+++ b/game.z80
@@ -271,13 +271,15 @@ ship_warning_over:
         call find_command
         cp 255
         jp z, no_handler
-
-        ; Call the handler
-        call JP_HL
+        push hl
 
         ; Valid command - increase turn count
         ld hl, TURN_COUNT
         inc (hl)
+
+        ; Call the handler
+        pop hl
+        call JP_HL
 
         ; Did we get eaten?
         call maybe_grue_death
@@ -1881,7 +1883,6 @@ turns_function:
         call show_msg
         ld hl, TURN_COUNT
         ld a, (hl)
-        inc a
         call show_a_register
         ld de, PLAYER_TURN_COUNT_END
         call show_msg

--- a/game.z80
+++ b/game.z80
@@ -412,12 +412,7 @@ CompareStringsWithLength:
 ; Helper function, to allow indirection.
 ;
 JP_HL:
-        ld bc, ret_obj
-        push bc
-	push hl
-ret_obj:
-        ret
-
+    jp (hl)
 
 
 ;


### PR DESCRIPTION
As discussed in #24 and #25, the turn counter is off-by-1 at the end of the game, because normally the turn count is output before it is incremented, so `turns_function` outputs `TURN_COUNT+1`.

This pull request makes the game increment the turn counter *before* running the command handler, so that `turns_function` no longer needs to increment the value it outputs, so that both the value displayed by `TURNS` command, and the value displayed at the end of the game, are correct.

I also simplified the `JP_HL` function, I think this version works but it's possible I misunderstood something about its operation and have subtly broken something - happy to be proven wrong on that one. I'm not a Z80 assembly language expert.

I'm also not sure if you'll be happy with pushing `hl`, incrementing the `TURN_COUNT`, and then popping `hl`. You might consider it inelegant? It was the simplest thing I could think of, but again I'd be happy to be shown something better.