### PR TITLE
Introduce a ZX Spectrum Port.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,4 +13,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        args: "*.com"
+        args: "*.com *.tap"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lihouse.com
 lihouse2.com
 lighthouse
 encrypt
+*.tap

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,18 @@
 VERSION := $(or ${GITHUB_REF},${GITHUB_REF},"unreleased-git")
 
 
-all: lighthouse
+all: lighthouse game-cpm game-spectrum
 
+# Build the C version
 lighthouse: handlers.c  inventory.c  items.c  main.c  world.c util.c
 	gcc  -o lighthouse -Os -Wall -Wextra -Werror handlers.c  inventory.c  items.c  main.c  world.c util.c
 
-clean:
-	rm -f lighthouse game.com lihouse.com lihouse2.com encrypt || true
 
+# Clean our generated output
+clean:
+	rm -f lighthouse *.com *.tap encrypt || true
+
+# Format our C-code
 format:
 	astyle --style=allman -A1 --indent=spaces=4   --break-blocks --pad-oper --pad-header --unpad-paren --max-code-length=200 *.c *.h
 
@@ -19,9 +23,13 @@ format:
 version:
 	echo "DB \"$$(echo ${VERSION} | awk -F/ '{print $$NF}' )\"" >  version.z80
 
-# build the game
-game: game.z80 version
-	pasmo --equ ENCRYPT_STRINGS=0 game.z80 lihouse.com
+# build the game for CP/M
+game-cpm: game.z80 bios.z80 version Makefile
+	pasmo --equ ENTRYPOINT=100 --equ ENCRYPT_STRINGS=0 --equ SPECTRUM=0 game.z80 lihouse.com
+
+# build the game for the ZX Spectrum
+game-spectrum: game.z80 bios.z80 version Makefile
+	pasmo --tapbas --equ ENTRYPOINT=32768 --equ ENCRYPT_STRINGS=0 --equ SPECTRUM=1 game.z80 lihouse.tap
 
 # Build the encryption helper
 encrypt: encrypt.c
@@ -29,9 +37,14 @@ encrypt: encrypt.c
 
 # Build the game for release - with strings encrypted
 release: game.z80 encrypt version
-	pasmo --equ ENCRYPT_STRINGS=1 game.z80 lihouse.com
+	pasmo --equ ENTRYPOINT=100 --equ ENCRYPT_STRINGS=1 --equ SPECTRUM=0 game.z80 lihouse.com
 	./encrypt
 	mv lihouse2.com lihouse.com
 
-run-game: game
+
+# Run for CP/M
+run-cpm: game
 	~/cpm/cpm lihouse
+
+run-spectrum:
+	xspect -quick-load -load-immed -tap *.tap

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ version:
 
 # build the game for CP/M
 game-cpm: game.z80 bios.z80 version Makefile
-	pasmo --equ ENTRYPOINT=100 --equ ENCRYPT_STRINGS=0 --equ SPECTRUM=0 game.z80 lihouse.com
+	pasmo --equ ENTRYPOINT=100h --equ ENCRYPT_STRINGS=0 --equ SPECTRUM=0 game.z80 lihouse.com
 
 # build the game for the ZX Spectrum
 game-spectrum: game.z80 bios.z80 version Makefile
@@ -37,7 +37,7 @@ encrypt: encrypt.c
 
 # Build the game for release - with strings encrypted
 release: game.z80 encrypt version
-	pasmo --equ ENTRYPOINT=100 --equ ENCRYPT_STRINGS=1 --equ SPECTRUM=0 game.z80 lihouse.com
+	pasmo --equ ENTRYPOINT=100h --equ ENCRYPT_STRINGS=1 --equ SPECTRUM=0 game.z80 lihouse.com
 	./encrypt
 	mv lihouse2.com lihouse.com
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ is a small amount of platform-specific code found in [bios.z80](bios.z80).
 The `Makefile` should build everything appropriately for both systems,
 defining `SPECTRUM`, and `ENTRYPOINT` as appropriate.
 
+
 ### Z80 Changes
 
 * Along the way I realized that having fixed inventory slots made the coding more of a challenge, so I made the location of each object a property of the object itself.
@@ -92,14 +93,15 @@ defining `SPECTRUM`, and `ENTRYPOINT` as appropriate.
 * There are __two__ victory conditions.
 * The Z80 version can be built with the text-strings, and game code, protected by simple XOR encryption
   * This stops users from looking through the binary for hints.
-  * Run `make release` to build the _protected_ version.
-  * Run `make game` to build a raw version.
+  * Run `make release` to build the _protected_ CP/M version.
+  * Run `make game-cpm` to build a raw CP/M version.
+  * Run `make game-spectrum` to build the ZX Spectrum version.
 
 
 ### Compiling & Running It
 
 Ensure you have the `pasmo` assembler installed, then build the code
-by running `make game`, or `make release`.
+by running `make`, or `make release`.
 
 In either case the output will be a binary named `lihouse.com` which you
 should be able to run upon your system - or under a CP/M emulator.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contain a simple text-based adventure game, implemented
 twice, once in portable C, and once in Z80 assembly language, targetted
-at the CP/M operating system.
+at both the CP/M operating system and the humble 48k ZX Spectrum.
 
 My intention was to write a simple text-based adventure game to run under
 CP/M.  Starting large projects in Z80 assembly language from scratch
@@ -78,15 +78,16 @@ The implementation uses a simple set of structures:
 * An item-table to store details about each object in the game.
 * A person table to store telephone messages.
 
-The whole implementation is defined in the file [game.z80](game.z80).
+The main implementation can be found in the file [game.z80](game.z80),
+but because we support two targets (CP/M 2.x and the ZX Spectrum) there
+is a small amount of platform-specific code found in [bios.z80](bios.z80).
 
-Along the way I did realize that having fixed inventory slots made the
-coding more of a challenge, so I made the location of each object a
-property of the object itself.
-
+The `Makefile` should build everything appropriately for both systems,
+defining `SPECTRUM`, and `ENTRYPOINT` as appropriate.
 
 ### Z80 Changes
 
+* Along the way I realized that having fixed inventory slots made the coding more of a challenge, so I made the location of each object a property of the object itself.
 * The Z80 version has more easter-eggs (Try typing "`xyzzy`" a few times).
 * There are __two__ victory conditions.
 * The Z80 version can be built with the text-strings, and game code, protected by simple XOR encryption

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # The Lighthouse of Doom
 
 This repository contain a simple text-based adventure game, implemented
-twice, once in portable C, and once in Z80 assembly language, targetted
-at both the CP/M operating system and the humble 48k ZX Spectrum.
+twice, once in portable C, and once in Z80 assembly language, available
+for both the CP/M operating system and the humble 48k ZX Spectrum.
 
 My intention was to write a simple text-based adventure game to run under
 CP/M.  Starting large projects in Z80 assembly language from scratch
 is a bit of a daunting prospect, so I decided to code the game in C first,
 so that I could get the design right, and avoid getting stuck in too many
-low-level details initially.
+low-level details initially.  Later I ported to the Spectrum, because
+it seemed like a fun challenge for myself!
 
 Quick links within this README file:
 
@@ -17,8 +18,8 @@ Quick links within this README file:
   * [Building & running it](#building--running-it)
 * [Z80 Implementation](#z80-implementation)
   * [Z80 Changes](#z80-changes)
-  * [Compiling & running it](#compiling--running-it)
-  * [Downloading It](#downloading-it)
+* [Compiling & running it](#compiling--running-it)
+* [Downloading It](#downloading-it)
 * [Bugs?](#bugs)
 
 
@@ -91,27 +92,37 @@ defining `SPECTRUM`, and `ENTRYPOINT` as appropriate.
 * Along the way I realized that having fixed inventory slots made the coding more of a challenge, so I made the location of each object a property of the object itself.
 * The Z80 version has more easter-eggs (Try typing "`xyzzy`" a few times).
 * There are __two__ victory conditions.
-* The Z80 version can be built with the text-strings, and game code, protected by simple XOR encryption
+* The CP/M version of the game can be built with the text-strings, and game code, protected by simple XOR encryption:
   * This stops users from looking through the binary for hints.
   * Run `make release` to build the _protected_ CP/M version.
   * Run `make game-cpm` to build a raw CP/M version.
-  * Run `make game-spectrum` to build the ZX Spectrum version.
 
 
-### Compiling & Running It
+## Compiling & Running It
 
-Ensure you have the `pasmo` assembler installed, then build the code
-by running `make`, or `make release`.
+Ensure you have the `pasmo` assembler installed, and then use the supplied Makefile to compile the game.
 
-In either case the output will be a binary named `lihouse.com` which you
-should be able to run upon your system - or under a CP/M emulator.
+Running `make` will generate the default targets:
+
+* `make lighthouse` -> Build the game for linux.
+* `make lihouse.com` -> Build the game for CP/M, without the XOR encryption.
+* `make lihouse.tap` -> Build the game for the 48k ZX Spectrum.
+
+If you wish to build only individual things then :
+
+* `make game-cpm` to build a normal CP/M version.
+* `make game-spectrum` to build the ZX Spectrum version.
+* `make lighthouse` will build the C-game for Linux
+* `make release` will build the _protected_ CP/M version.
 
 
-### Downloading It
+
+## Downloading It
 
 If you look on our [release page](https://github.com/skx/lighthouse-of-doom/releases/) you can find the latest stable build.
 
-Transfer `lihouse.com` to your system, and run `LIHOUSE` to launch it.
+* For CP/M download `lihouse.com` to your system, and then run `LIHOUSE` to launch it.
+* For the ZX Spectrum download `lihouse.tap` to your system, and then launch in your favourite emulator.
 
 
 ## Bugs?
@@ -121,7 +132,7 @@ Report any bugs as you see them:
 * A crash of the game is a bug.
 * Bad spelling, grammar, or broken punctuation are also bugs.
 * Getting into a zombie-state where winning or losing are impossible is a bug.
-  * Albeit unlikely!
+
 
 
 Steve

--- a/bios.z80
+++ b/bios.z80
@@ -67,11 +67,12 @@ ENDIF
 
 
 ;
-; Await a keypress, which is ignored
+; Await a keypress, which is returned in the A-register
 ;
 bios_await_keypress:
 
 IF SPECTRUM
+       push hl
        LD   HL,LASTK
        LD   A,255
        LD (HL),A
@@ -80,6 +81,7 @@ wkey:  CP   (HL)
 
        ; get the key, and return it.
        ld a,(HL)
+       pop hl
        ret
 
 ELSE
@@ -147,7 +149,7 @@ ENDIF
 
 
 ;
-; Prompt the user for a line of input
+; Prompt the user for a line of input.
 ;
 ; The way this works is you pass the address of a region of memory,
 ; in the DE register.  The first byte is the length of the buffer.
@@ -155,9 +157,53 @@ ENDIF
 ; On return the second byte of the buffer will be populated by the
 ; amount of text which was read, then the input itself:
 ;
+; DE points to the memory buffer;
+;
+;  0x00 - buffer size
+;  0x01 - read-length
+;  0x02 ... char..
 bios_read_input:
 IF SPECTRUM
         PUSH_ALL
+
+        push de
+        pop  hl   ; buffer -> hl
+
+        inc hl    ; skip to the returned size
+        inc de
+
+        xor a
+        ld (hl),a  ; size is now zero
+        inc hl ; point to the character
+
+read_input_again:
+        ; read a char
+        call bios_await_keypress
+
+        cp 13
+        jr z, read_input_over
+
+        ; display it
+        push de
+        ld e,a
+        call bios_output_character
+        pop de
+
+        ; add the character to the buffer
+        ld (hl),a
+        inc hl
+
+        ; increase the input count
+        ld a,(de)
+        inc a
+        ld (de),a
+
+        ; repeat
+        jr read_input_again
+
+read_input_over:
+        push af
+        pop af
         POP_ALL
         ret
 ELSE

--- a/bios.z80
+++ b/bios.z80
@@ -1,0 +1,166 @@
+; bios.z80
+;
+; This file contains the common primitives we use for interfacing
+; with CP/M or the ZX Spectrum (48k).
+;
+; We don't use many primitives, but we do need some facilities from
+; the operating system, or the Spectrum ROM:
+;
+;  1.  Pause for a keypress.
+;
+;  2.  Clear the screen.
+;
+;  3.  Output a string.
+;
+;  4.  Allow the user to enter input
+;
+; The routines here will work for both systems, and contain the only
+; platform-specific code we need.
+;
+
+
+; Last keyboard input as set by the Spectrum ROM
+LASTK: EQU 0x5C08
+
+
+;
+; Initialization routine for the BIOS, if needed
+;
+bios_init:
+
+IF SPECTRUM
+   ld a,2
+   call 5633    ; CHAN_OPEN
+
+   ld hl, 23692
+   ld (hl),255
+   ret
+ELSE
+   ret
+ENDIF
+
+
+;
+; Clear the screen.
+;
+bios_clear_screen:
+
+IF SPECTRUM
+        PUSH_ALL
+        ld a,2
+        call 0x1601  ; ROM_OPEN_CHANNEL
+        call 0x0DAF  ; ROM_CLS
+        POP_ALL
+        ret
+
+ELSE
+        ld de, cpm_clear_screen_msg
+        call show_msg
+        ret
+
+cpm_clear_screen_msg:
+        db 27, "[2J"            ; "clear"
+        db 27, "[H"             ; "home"
+        db "$"
+ENDIF
+
+
+;
+; Await a keypress, which is ignored
+;
+bios_await_keypress:
+
+IF SPECTRUM
+       LD   HL,LASTK
+       LD   A,255
+       LD (HL),A
+wkey:  CP   (HL)
+       JR   Z,wkey
+
+       ; get the key, and return it.
+       ld a,(HL)
+       ret
+ELSE
+        ld c,  0x01
+        call 0x0005
+        ret
+
+ENDIF
+
+
+
+;
+; Output a single character, stored in the E register
+;
+bios_output_character:
+
+IF SPECTRUM
+        PUSH_ALL
+        ld a,e
+        RST 0x10
+        POP_ALL
+        ret
+ELSE
+         ld c, 0x02
+         call 0x005
+         ret
+ENDIF
+
+
+;
+; Output a string, terminated by "$".
+;
+; The address of the string is stored in DE
+;
+; NOTE: / TODO: The Spectrum only wants a newline, not a character return.
+bios_output_string:
+
+IF SPECTRUM
+        PUSH_ALL
+        push DE
+        pop HL      ; HL contains the string
+bios_output_repeat:
+        ld a,(hl)   ; Get the character
+        cp 0x0d     ; Ignore the newline & cr.
+        jr z, skip
+        cp 0x0a
+        jr z, skip
+        cp '$'      ; end of string?
+        jr z, bios_output_done
+        ld e,a      ; output the single character
+        call bios_output_character
+skip:
+        inc hl
+        jr bios_output_repeat
+bios_output_done:
+        POP_ALL
+        ret
+ELSE
+        ld c, 0x09
+        call 0x005
+        ret
+ENDIF
+
+
+;
+; Prompt the user for a line of input
+;
+; The way this works is you pass the address of a region of memory,
+; in the DE register.  The first byte is the length of the buffer.
+;
+; On return the second byte of the buffer will be populated by the
+; amount of text which was read, then the input itself:
+;
+bios_read_input:
+IF SPECTRUM
+        PUSH_ALL
+        xor a
+        inc de
+        ld (de),a
+        POPALL
+        ret
+ELSE
+        ld c, 0x0A
+        call 0x005
+        ret
+ENDIF

--- a/bios.z80
+++ b/bios.z80
@@ -166,7 +166,8 @@ bios_read_input:
 IF SPECTRUM
         PUSH_ALL
 
-        ; Move the cursor to the bottom of the screen
+        ; Move the cursor to the bottom of the screen, and
+        ; display a prompt
         PUSH_ALL
         ld a,22          ; AT code.
         rst 16
@@ -174,6 +175,9 @@ IF SPECTRUM
         rst 16           ; set the vertical coord
         ld a,0           ; horizontal position.
         rst 16           ; set the horizontal coord.
+
+        ld e, ">"
+        call bios_output_character
         POP_ALL
 
         push de
@@ -212,12 +216,20 @@ read_input_again:
         jr read_input_again
 
 read_input_over:
-        push af
-        pop af
+        ; move the cursor to the top of the screen, and
+        ; prepare for output again.
+        call bios_clear_screen
+
         POP_ALL
         ret
 ELSE
+        ; 3. show the prompt
+        ld de, prompt_message
+        call bios_output_string
+
         ld c, 0x0A
         call 0x005
         ret
+prompt_message:
+        db 0x0a, 0x0d,">$"
 ENDIF

--- a/bios.z80
+++ b/bios.z80
@@ -166,6 +166,16 @@ bios_read_input:
 IF SPECTRUM
         PUSH_ALL
 
+        ; Move the cursor to the bottom of the screen
+        PUSH_ALL
+        ld a,22          ; AT code.
+        rst 16
+        ld a,21          ; vertical coord.
+        rst 16           ; set the vertical coord
+        ld a,0           ; horizontal position.
+        rst 16           ; set the horizontal coord.
+        POP_ALL
+
         push de
         pop  hl   ; buffer -> hl
 

--- a/bios.z80
+++ b/bios.z80
@@ -158,21 +158,7 @@ ENDIF
 bios_read_input:
 IF SPECTRUM
         PUSH_ALL
-        push de
-        pop hl
-
-        ld a,4
-        inc hl
-        ld (hl),a
-        inc hl
-        ld (hl), "h"
-        inc hl
-        ld (hl), "e"
-        inc hl
-        ld (hl), "l"
-        inc hl
-        ld (hl), "p"
-        POPALL
+        POP_ALL
         ret
 ELSE
         ld c, 0x0A

--- a/bios.z80
+++ b/bios.z80
@@ -35,6 +35,7 @@ IF SPECTRUM
    ld hl, 23692
    ld (hl),255
    ret
+
 ELSE
    ret
 ENDIF
@@ -55,7 +56,7 @@ IF SPECTRUM
 
 ELSE
         ld de, cpm_clear_screen_msg
-        call show_msg
+        call bios_output_string
         ret
 
 cpm_clear_screen_msg:
@@ -80,11 +81,11 @@ wkey:  CP   (HL)
        ; get the key, and return it.
        ld a,(HL)
        ret
-ELSE
-        ld c,  0x01
-        call 0x0005
-        ret
 
+ELSE
+       ld c,  0x01
+       call 0x0005
+       ret
 ENDIF
 
 
@@ -101,9 +102,9 @@ IF SPECTRUM
         POP_ALL
         ret
 ELSE
-         ld c, 0x02
-         call 0x005
-         ret
+        ld c, 0x02
+        call 0x005
+        ret
 ENDIF
 
 
@@ -112,7 +113,9 @@ ENDIF
 ;
 ; The address of the string is stored in DE
 ;
-; NOTE: / TODO: The Spectrum only wants a newline, not a character return.
+; NOTE: / TODO: The Spectrum will process the string character by
+;               character to skip the CR/NL things it can't show.
+;
 bios_output_string:
 
 IF SPECTRUM
@@ -135,6 +138,7 @@ skip:
 bios_output_done:
         POP_ALL
         ret
+
 ELSE
         ld c, 0x09
         call 0x005
@@ -154,9 +158,20 @@ ENDIF
 bios_read_input:
 IF SPECTRUM
         PUSH_ALL
-        xor a
-        inc de
-        ld (de),a
+        push de
+        pop hl
+
+        ld a,4
+        inc hl
+        ld (hl),a
+        inc hl
+        ld (hl), "h"
+        inc hl
+        ld (hl), "e"
+        inc hl
+        ld (hl), "l"
+        inc hl
+        ld (hl), "p"
         POPALL
         ret
 ELSE

--- a/bios.z80
+++ b/bios.z80
@@ -6,44 +6,84 @@
 ; We don't use many primitives, but we do need some facilities from
 ; the operating system, or the Spectrum ROM:
 ;
-;  1.  Pause for a keypress.
+;  Pause for a keypress.
 ;
-;  2.  Clear the screen.
+;  Clear the screen.
 ;
-;  3.  Output a string.
+;  Output a string.
 ;
-;  4.  Allow the user to enter input
+;  Allow the user to enter input
+;
+;  Pause for a "small delay"
 ;
 ; The routines here will work for both systems, and contain the only
 ; platform-specific code we need.
 ;
 
 
-; Last keyboard input as set by the Spectrum ROM
-LASTK: EQU 0x5C08
-
-
 ;
 ; Initialization routine for the BIOS, if needed
-;
+; {{
 bios_init:
 
 IF SPECTRUM
    ld a,2
    call 5633    ; CHAN_OPEN
-
-   ld hl, 23692
-   ld (hl),255
+ENDIF
    ret
+; }}
+
+;
+; Delay for "a short while".
+;
+; This is used for showing "dots" in the SLEEP command, or when the
+; grue is threatening you..
+;
+; {{
+bios_delay:
+
+IF SPECTRUM
+   PUSH_ALL
+wait:
+   ld hl,pretim        ; previous time setting
+   ld a,(23672)        ; current timer setting set by ZX Spectrum
+   sub (hl)            ; difference between the two.
+   cp 2                ; have two frames elapsed yet?
+   jr nc,wait0         ; yes, no more delay.
+   jp wait
+wait0:
+   ld a,(23672)        ; current timer.
+   ld (hl),a           ; store this setting.
+   POP_ALL
+   ret
+
+pretim: defb 0
 
 ELSE
-   ret
+    ; Random values found by experimentation with my own system
+    ld hl,0xffff / 8
+hl_delay_loop:
+    inc hl
+    ld de, 0xffff - 10
+de_delay_loop:
+    inc de
+    ld a, d
+    or e
+    jr nz, de_delay_loop
+    ld a,h
+    or l
+    jr nz, hl_delay_loop
+    ret
+
 ENDIF
+;; }}
+
 
 
 ;
 ; Clear the screen.
 ;
+; {{
 bios_clear_screen:
 
 IF SPECTRUM
@@ -64,89 +104,96 @@ cpm_clear_screen_msg:
         db 27, "[H"             ; "home"
         db "$"
 ENDIF
-
+; }}
 
 ;
-; Await a keypress, which is returned in the A-register
+; Await a keypress.  The pressed-key will be returned in the A-register.
 ;
+; {{
 bios_await_keypress:
 
 IF SPECTRUM
        push hl
-       LD   HL,LASTK
-       LD   A,255
-       LD (HL),A
-wkey:  CP   (HL)
-       JR   Z,wkey
+       ld   hl, 0x5C08   ; LASTK - Set by the Spectrum ROM
+       ld   a,255
+       ld (hl),a
+await_key:
+       cp   (hl)
+       jr   z,await_key
 
        ; get the key, and return it.
-       ld a,(HL)
+       ld a,(hl)
        pop hl
        ret
-
 ELSE
        ld c,  0x01
        call 0x0005
        ret
 ENDIF
-
+; }}
 
 
 ;
-; Output a single character, stored in the E register
+; Output a single character, stored in the E register.
 ;
+; {{
 bios_output_character:
-
-IF SPECTRUM
         PUSH_ALL
+IF SPECTRUM
+        ; output the character
         ld a,e
         RST 0x10
-        POP_ALL
-        ret
 ELSE
         ld c, 0x02
         call 0x005
-        ret
 ENDIF
-
+        POP_ALL
+        ret
+; }}
 
 ;
 ; Output a string, terminated by "$".
 ;
-; The address of the string is stored in DE
+; The address of the string is stored in DE.  The spectrum version
+; will replace unprintable character from the \r\n pair with a space.
 ;
-; NOTE: / TODO: The Spectrum will process the string character by
-;               character to skip the CR/NL things it can't show.
+; To cope with inline newlines we'll count the length of the string
+; and call the ROM printing routine.
 ;
+; NOTE/TODO: This means we need to beware of the SCROLL (Y/N) prompt
+;
+; {{
 bios_output_string:
-
-IF SPECTRUM
         PUSH_ALL
-        push DE
-        pop HL      ; HL contains the string
-bios_output_repeat:
-        ld a,(hl)   ; Get the character
-        cp 0x0d     ; Ignore the newline & cr.
-        jr z, skip
-        cp 0x0a
-        jr z, skip
-        cp '$'      ; end of string?
-        jr z, bios_output_done
-        ld e,a      ; output the single character
-        call bios_output_character
-skip:
-        inc hl
-        jr bios_output_repeat
-bios_output_done:
-        POP_ALL
-        ret
+IF SPECTRUM
+        ; DE contains the string
+        ; We want to get BC containing the string length
+        push de
+        ld bc, 0
+length_check:
+        ld a,(de)
 
+        ; replace 0x0a with a space
+        cp 0x0a
+        jr nz, continue_print
+        ld a,32
+        ld (de),a
+continue_print:
+        cp '$'
+        jr z, length_found
+        inc bc
+        inc de
+        jr length_check
+length_found:
+        pop de
+        call 0x203C
 ELSE
         ld c, 0x09
         call 0x005
-        ret
 ENDIF
-
+        POP_ALL
+        ret
+; }}
 
 ;
 ; Prompt the user for a line of input.
@@ -162,6 +209,7 @@ ENDIF
 ;  0x00 - buffer size
 ;  0x01 - read-length
 ;  0x02 ... char..
+; {{
 bios_read_input:
 IF SPECTRUM
         PUSH_ALL
@@ -194,9 +242,19 @@ read_input_again:
         ; read a char
         call bios_await_keypress
 
+        ; return?  Then we're done
         cp 13
         jr z, read_input_over
 
+        ; delete?  trash the input and start again.
+        cp 12
+        jr z, reset_line
+
+        ; escape? trash the input and start again.
+        cp 7
+        jr z, reset_line
+
+not_backspace:
         ; display it
         push de
         ld e,a
@@ -215,6 +273,12 @@ read_input_again:
         ; repeat
         jr read_input_again
 
+reset_line:
+        ; clear the screen, and restart the input process
+        call bios_clear_screen
+        POP_ALL
+        jr bios_read_input
+
 read_input_over:
         ; move the cursor to the top of the screen, and
         ; prepare for output again.
@@ -224,12 +288,14 @@ read_input_over:
         ret
 ELSE
         ; 3. show the prompt
+        push de
         ld de, prompt_message
         call bios_output_string
-
+        pop de
         ld c, 0x0A
         call 0x005
         ret
 prompt_message:
         db 0x0a, 0x0d,">$"
 ENDIF
+; }}

--- a/game.z80
+++ b/game.z80
@@ -204,16 +204,13 @@ not_dead:
         jp 0x0000
 
 not_won:
-        ; 3. show the prompt
-        ld de, prompt_message
-        call bios_output_string
 
-        ; 4. Erase our input buffer.
+        ; 3. Erase our input buffer.
         ld hl, INPUT_BUFFER+2
         ld b, 0xff
         call erase_buffer
 
-        ; 5. Read a line of input from the player.
+        ; 4. Read a line of input from the player.
         ld de, INPUT_BUFFER
         call bios_read_input
 
@@ -239,7 +236,7 @@ ship_warning_over:
         cp 0
         jr z, not_won
 
-        ; 6. Convert the input to upper-case.
+        ; 5. Convert the input to upper-case.
         ld b,a
         inc hl
         call uppercase_buffer
@@ -254,7 +251,7 @@ ship_warning_over:
         ; Not ideal, but more useable
         call filter_input_buffer
 
-        ;  7.  Take the input from the user, and see if we have a registered
+        ; 6.  Take the input from the user, and see if we have a registered
         ; command with that name.  If we do we can invoke it, but if not we've
         ; been given something we don't understand.
         ld hl, INPUT_BUFFER+2
@@ -2656,8 +2653,6 @@ cant_take_that_msg:
         db 0x0a, 0x0d, "You can't take that.", 0x0a, 0x0d, "$"
 you_drop_it:
         db 0x0a, 0x0d, "You drop it", 0x0a, 0x0d, "$"
-prompt_message:
-        db 0x0a, 0x0d,">$"
 inventory_empty_message:
         db 0x0a, 0x0d, "You are not carrying anything", 0x0a, 0x0d, "$"
 you_carrying_message:

--- a/game.z80
+++ b/game.z80
@@ -8,13 +8,11 @@
 ;
 ;
 ; This is a port of the lighthouse-of-doom game from C to Z80 assembly, such
-; that it will run under CP/M 2.x.
-;
+; that it will run under CP/M 2.x and the 48k ZX Spectrum.
 ;
 ; Although the game has been ported that process has resulted in some changes
 ; to the text, and the command-handlers.  If you've played the C game, and
 ; completed it, there will be no significant new surprises.
-;
 ;
 ; Rather than having a global player-inventory store, and a place
 ; in each location for object storage we've instead make the location
@@ -50,7 +48,7 @@
 MAX_TURN_LIMIT: EQU 100
 
 ; Maximum number of turns you can survive being near a grue
-MAX_GRUE_EXPOSURE: EQU 5
+MAX_GRUE_EXPOSURE: EQU 3
 
 
 
@@ -71,7 +69,7 @@ MACRO FAKE_LOOK
 
 
 ;
-; Simple macro to push all registers
+; Simple macro to push all (important) registers.
 ;
 MACRO PUSH_ALL
         push af
@@ -83,7 +81,7 @@ MACRO PUSH_ALL
 
 
 ;
-; Simple macro to pop all registers
+; Simple macro to pop all (important) registers.
 ;
 MACRO POP_ALL
         pop hl
@@ -95,16 +93,16 @@ MACRO POP_ALL
 
 
         ;
-        ; Entry-point of CP/M binaries is 0x100.
-        ;
-        ; The zero-page, or PSP, is located before that:
+        ; Entry-point of CP/M binaries is 0x100, as the zero-page, or PSP,
+        ; is located before that:
         ;
         ;     https://en.wikipedia.org/wiki/Zero_page_(CP/M)
         ;
+        ; Entry-point for the ZX Spectrum port is 32768, chosen randomly.
+        ;
         ORG ENTRYPOINT
 
-        ; Call system-specific setup routine before we
-        ; do anything else.
+        ; Call system-specific setup routine before we do anything else.
         call bios_init
 
         ;
@@ -133,7 +131,6 @@ enc_loop:
         or e
         jr nz,enc_loop     ; no, then repeat
 
-
         jp enc_end         ; Jump over our marker to the start of the game.
 
         ;
@@ -142,6 +139,30 @@ enc_loop:
         ENC: DB "SKX"
 enc_end:
 ENDIF
+
+        ; Here we're going to copy our game-state to the end of RAM
+        ;
+        ; We do this so that everything "resets" if the player dies/wins
+        ; and then chooses to play again when prompted.
+        ;
+        ; We don't know for sure how big the data is, but we assume it'll
+        ; fit from 0xD000..
+        ld hl, per_game_state_start
+        ld de, 0xD000
+        ld bc, end_of_source - per_game_state_start
+        ldir
+
+game_start:
+
+        ; Reset the state of the the inventory, the game-world, etc.
+        ;
+        ; This is pointless at the start of the game, as nothing is
+        ; modified, but we jump here if the user chooses to replay the
+        ; game, so we have it here for that reason.
+        ld hl, 0xD000
+        ld de, per_game_state_start
+        ld bc, end_of_source - per_game_state_start
+        ldir
 
         ; Clear the screen
         call bios_clear_screen
@@ -167,19 +188,25 @@ ENDIF
         ; command/dispatch-table.
 game_loop:
 
-        ; 0. Have we died?
+        ; Have we exceeded the turn-count?
         ld hl, TURN_COUNT
         ld a, (hl)
         cp MAX_TURN_LIMIT
         jp c,game_loop_continue
 
-        ld hl, PLAYER_DEAD
+        ld hl, PLAYER_DEAD_FLAG
         inc (hl)
 
 game_loop_continue:
 
-        ; 1. Is the player dead?
-        ld hl, PLAYER_DEAD
+        ; Did the player die of a magic-overdoes
+        ld hl, PLAYER_MAGIC_OVERDOSE_FLAG
+        ld a, (hl)
+        cp 1
+        jp z, play_again
+
+        ; Is the player dead?
+        ld hl, PLAYER_DEAD_FLAG
         ld a, (hl)
         cp 1
         jp nz,not_dead
@@ -188,11 +215,11 @@ game_loop_continue:
         ld de, PLAYER_DEAD_MESSAGE
         call bios_output_string
         call turns_function
-        jp 0x0000
+        jr play_again
 
 not_dead:
-        ; 2. Did the player win?
-        ld hl, PLAYER_WON
+        ; Did the player win?
+        ld hl, PLAYER_WON_FLAG
         ld a, (hl)
         cp 1
         jp nz, not_won
@@ -201,21 +228,20 @@ not_dead:
         ld de, PLAYER_WON_MESSAGE
         call bios_output_string
         call turns_function
-        jp 0x0000
+        jr play_again
 
 not_won:
 
-        ; 3. Erase our input buffer.
+        ; Erase our input buffer.
         ld hl, INPUT_BUFFER+2
         ld b, 0xff
         call erase_buffer
 
-        ; 4. Read a line of input from the player.
+        ; Read a line of input from the player.
         ld de, INPUT_BUFFER
         call bios_read_input
 
         ; Every five turns we show a message about the ship.
-        ;
         ld hl, SHIP_WARNING
         ld a, (hl)              ; get the value
         cp 5                    ; five turns?
@@ -236,7 +262,7 @@ ship_warning_over:
         cp 0
         jr z, not_won
 
-        ; 5. Convert the input to upper-case.
+        ; Convert the input to upper-case.
         ld b,a
         inc hl
         call uppercase_buffer
@@ -251,7 +277,7 @@ ship_warning_over:
         ; Not ideal, but more useable
         call filter_input_buffer
 
-        ; 6.  Take the input from the user, and see if we have a registered
+        ; Take the input from the user, and see if we have a registered
         ; command with that name.  If we do we can invoke it, but if not we've
         ; been given something we don't understand.
         ld hl, INPUT_BUFFER+2
@@ -283,10 +309,46 @@ no_handler:
         ; Did we get eaten?
         call maybe_grue_death
 
-        ;  8.  Goto 1
-        jp game_loop              ; restart
+        ; Return to the start of our game-loop.
+        jp game_loop
 
 
+
+;
+; Ask the user if they wish to play again
+;
+play_again:
+        ld de, play_again_msg
+        call bios_output_string
+
+        call bios_await_keypress
+        cp 'y'
+        jr z, play_again_yes
+        cp 'Y'
+        jr z, play_again_yes
+        cp 'n'
+        jr z, play_again_no
+        cp 'N'
+        jr z, play_again_no
+        call bios_clear_screen
+        jr play_again
+
+
+; User chose "Y" to "play again?"
+play_again_yes:
+        jp game_start
+
+; User chose "N" to "play again?"
+play_again_no:
+        ld de, play_again_no
+        call bios_output_string
+IF SPECTRUM
+        ret
+ELSE
+        ld c, 0x0
+        call 0x0005
+        ret
+ENDIF
 
 
 ; This will be a major part of our code so it is perhaps a little more
@@ -408,29 +470,16 @@ JP_HL:
 ; Show some significant dots
 ;
 show_dots:
+        ; forty dots
         ld b, 40
-
-hl_delay:
-         ld hl,0xffff / 8
-hl_delay_loop:
-         inc hl
-            ld de, 0xffff - 10
-de_delay_loop:
-            inc de
-            ld a, d
-            or e
-            jr nz, de_delay_loop
-         ld a,h
-         or l
-         jr nz, hl_delay_loop
-
-         PUSH_ALL
-         ld e, "."
+dot_loop:
+        PUSH_ALL
+         call bios_delay
+         ld e, '.'
          call bios_output_character
-         POP_ALL
-       djnz hl_delay
-
-       ret
+        POP_ALL
+        djnz dot_loop
+        ret
 
 
 
@@ -855,11 +904,11 @@ death_by_grue_grue:
         ld de, you_were_eaten
         call bios_output_string
 
-        ld hl,PLAYER_DEAD
+        ld hl,PLAYER_DEAD_FLAG
         inc (hl)
 
         call turns_function
-        jp 0x0000
+        jp play_again
         ret
 
 ;
@@ -1769,7 +1818,7 @@ item_not_present:
 ; Show a different message each time this is called, until you are killed.
 ;
 magic_function:
-        ld hl, MAGIC_LOCATION
+        ld hl, MAGIC_COUNT
         ld a,(hl)
         inc a
         ld (hl),a
@@ -1788,7 +1837,7 @@ magic_function:
         call bios_output_string
 
         ; you're dead
-        ld hl, PLAYER_DEAD
+        ld hl, PLAYER_MAGIC_OVERDOSE_FLAG
         inc (hl)
         ret
 magic_one:
@@ -1816,10 +1865,122 @@ quit_function:
         ld de, QUIT_MSG
         call bios_output_string
         call turns_function
-        jp 0x0000
+        jp play_again
 
 
 
+;
+; Command-handler: BIOS
+;
+bios_function:
+        call bios_clear_screen
+        ld de, BIOS_MSG
+        call bios_output_string
+
+bios_function_menu:
+        call bios_await_keypress
+        cp '1'
+        jr nz, not_one
+
+        ; 1. Clear screen
+        call bios_clear_screen
+        jr bios_function
+
+not_one:
+        cp '2'
+        jr nz, not_two
+
+        ; 2. Show a character
+        ld e, '*'
+        call bios_output_character
+        jr bios_function_menu
+
+not_two:
+        cp '3'
+        jr nz, not_three
+
+        ; 3. Input test
+        call bios_clear_screen
+
+        ; 24 characters, default to zero read
+        ld hl, INPUT_BUFFER
+        ld (hl),24
+        inc hl
+        ld (hl), 0
+
+        ld de, INPUT_BUFFER
+        call bios_read_input
+
+        ld hl, INPUT_BUFFER+1
+        ld a,(hl)
+        cp 0
+        jr nz, show_input_buffer
+
+        ld de, no_input
+        call bios_output_string
+        jr pause_for_key
+
+show_input_buffer:
+        ld hl, INPUT_BUFFER
+        inc hl
+        ld b, (hl)
+skip_forward:
+        inc hl
+        djnz skip_forward
+        inc hl
+        ld (hl), '$'
+
+        ld de, you_entered_message
+        call bios_output_string
+        ld de, INPUT_BUFFER+2
+        call bios_output_string
+
+pause_for_key:
+        ld de, press_key_continue
+        call bios_output_string
+        call bios_await_keypress
+bios_function_indirect:
+        jr bios_function
+not_three:
+        cp '4'
+        jr nz,  not_four
+
+        ; 4. delay test
+        call bios_clear_screen
+        ld b, 10
+delay_loop:
+        PUSH_ALL
+         call bios_delay
+         ld e, '.'
+         call bios_output_character
+        POP_ALL
+        djnz delay_loop
+        jr bios_function_indirect
+
+not_four:
+        cp '5'
+        jr nz, not_five
+        ld de, you_pressed
+        call bios_output_string
+        call bios_await_keypress
+        push af
+        call show_a_register
+        ld e, "<"
+        call bios_output_character
+        pop af
+        ld e,a
+        call bios_output_character
+        ld e, ">"
+        call bios_output_character
+
+        jr pause_for_key
+
+not_five:
+        cp '6'
+        jr nz, bios_function_indirect
+        call bios_clear_screen
+        FAKE_LOOK
+        ret
 
 ;
 ; Command-Handler SLEEP
@@ -1955,7 +2116,7 @@ up_on_middle_floor:
 
         ; We're on the middle-floor, going up, carrying the meteor.
         ; That's an easy victory.
-        ld hl, PLAYER_WON
+        ld hl, PLAYER_WON_FLAG
         inc (hl)
 
         ; Show the successful result
@@ -2498,7 +2659,7 @@ use_generator_found_t:
         call bios_output_string
         ret
 use_generator_won_fn:
-        ld hl, PLAYER_WON
+        ld hl, PLAYER_WON_FLAG
         ld (hl),1
 
         ld de, use_generator_won
@@ -2516,15 +2677,18 @@ include "bios.z80"
 ; Data / State Storage
 ;********************************************************************
 ; {
+per_game_state_start:
 TURN_COUNT:
         db 0         ; count of turns
 CURRENT_LOCATION:
         db 0         ; offset into location table
-PLAYER_DEAD:
+PLAYER_MAGIC_OVERDOSE_FLAG:
+        db 0
+PLAYER_DEAD_FLAG:
         db 0         ; 1 iff player is dead
-PLAYER_WON:
+PLAYER_WON_FLAG:
         db 0         ; 1 iff player has won
-MAGIC_LOCATION
+MAGIC_COUNT:
         db 0         ; state for magic-function
 SHIP_WARNING:
         db 0         ; State for showing a "ship closer" message.
@@ -2637,6 +2801,24 @@ meteor_saves_the_day:
 
 QUIT_MSG:
         db 0x0a, 0x0d, "You said 'QUIT' so we terminate!", 0x0a, 0x0d, "$"
+BIOS_MSG:
+        db 0x0a, 0x0d, "BIOS test-function"
+        db 0x0a, 0x0d, "1.  Clear the screen"
+        db 0x0a, 0x0d, "2.  Write a character"
+        db 0x0a, 0x0d, "3.  Input test"
+        db 0x0a, 0x0d, "4.  Delay test"
+        db 0x0a, 0x0d, "5.  Input character display"
+        db 0x0a, 0x0d, "6.  Return to the game"
+        db 0x0a, 0x0d
+        db "$"
+you_entered_message:
+        db 0x0a, 0x0d, 0x0a, 0x0d, "You entered: $"
+no_input:
+        db "You didn't enter anything.$"
+you_pressed:
+        db 0x0a,0x0d,0x0a,0x0d, "You pressed:$"
+press_key_continue:
+        db 0x0a, 0x0d, 0x0a, 0x0d, "Press a key to continue$"
 HELP_MSG:
         db 0x0a, 0x0d, "The following commands are available:", 0x0a, 0x0d, "$"
 EXAMINE_WHAT_MSG:
@@ -2739,19 +2921,18 @@ include "version.z80"
         db "Press any key to start.$"
 ENDIF
 
+play_again_msg:
+        db 0x0a, 0x0d, "Play again? (y/n)$"
+play_again_no_msg:
+        db 0x0a, 0x0d, "Resetting$"
 PLAYER_DEAD_MESSAGE:
         db 0x0a, 0x0d, "Unfortunately you took too long to fix the broken light."
-        db 0x0a, 0x0d
         db 0x0a, 0x0d, "The ship ploughs into the base of your lighthouse, causing it to collapse around"
         db 0x0a, 0x0d, "you."
-        db 0x0a, 0x0d
         db 0x0a, 0x0d, "You're buried and helpless, and as the darkness consumes you the sounds of the"
         db 0x0a, 0x0d, "sailors thrashing in the water reach you, from a distance."
-        db 0x0a, 0x0d
         db 0x0a, 0x0d, "Let us hope some of them can swim to shore.."
 
-        db 0x0a, 0x0d
-        db 0x0a, 0x0d
         db "Game over - you're dead."
         db 0x0a, 0x0d,"$"
 PLAYER_WON_MESSAGE:
@@ -2774,21 +2955,27 @@ LOOK_AT:
 location_0_short:
         db "the top floor of the lighthouse.$"
 location_0_long:
+IF SPECTRUM
+ELSE
         db "The lighthouse has a spiral staircase which runs from top to bottom.", 0x0a, 0x0d, 0x0a, 0x0d
+ENDIF
         db "Through the window you can see the lights of an approaching ship, and you know", 0x0a, 0x0d
         db "that without the lighthouse's beacon it will surely crash upon the rocks your", 0x0a, 0x0d
-        db "lighthouse is built upon.  If the ship crashes not only will the sailors drown,", 0x0a, 0x0d
+        db "lighthouse is built upon. "
+
+IF SPECTRUM
+        db 0x0a, 0x0d
+ELSE
+        db "If the ship crashes not only will the sailors drown,", 0x0a, 0x0d
+ENDIF
         db "the lighthouse itself is liable to be seriously damaged.", 0x0a, 0x0d, 0x0a, 0x0d
-        db "Too bad the lighthouse light doesn't seem to be working, it looks like", 0x0a, 0x0d
-        db "there's a problem with the power.", 0x0a, 0x0d
+        db "Too bad the lighthouse light doesn't seem to be working..", 0x0a, 0x0d
         db "$"
 
 location_1_short:
         db "the middle floor of the lighthouse.$"
 location_1_long:
-        db "The middle floor of the lighthouse seems to be a relaxation-room,", 0x0a, 0x0d
-        db "you see some comfy chairs, a work-desk, as well as various odds and", 0x0a, 0x0d
-        db "ends.", 0x0a, 0x0d, 0x0a, 0x0d
+        db "This seems to be a relaxation-room, you see some comfy chairs, a work-desk, as well as various odds and ends.", 0x0a, 0x0d
         db "An impressive painting hangs over the desk, and a dog sleeps in a basket", 0x0a, 0x0d
         db "to the side of it.", 0x0a, 0x0d
         db "$"
@@ -2938,12 +3125,14 @@ command_table:
           DEFW get_function
         DEFB 4, 'HELP', 0
           DEFW help_function
-        DEFB 4, 'LOOK', 0
-          DEFW look_function
         DEFB 9, 'INVENTORY', 0
           DEFW inventory_function
+        DEFB 4, 'LOOK', 0
+          DEFW look_function
         DEFB 4, 'QUIT', 0
           DEFW quit_function
+        DEFB 4, 'BIOS', 1
+          DEFW bios_function
         DEFB 5, 'TURNS', 0
           DEFW turns_function
         DEFB 2, 'UP', 0

--- a/game.z80
+++ b/game.z80
@@ -148,7 +148,7 @@ ENDIF
 
         ; Present the game intro-text.
         ld de, usage_message
-        call show_msg
+        call bios_output_string
 
         ; Pause for input here.
         call bios_await_keypress
@@ -186,7 +186,7 @@ game_loop_continue:
 
         ; The player is dead.  Oops.
         ld de, PLAYER_DEAD_MESSAGE
-        call show_msg
+        call bios_output_string
         call turns_function
         jp 0x0000
 
@@ -199,14 +199,14 @@ not_dead:
 
         ; The player won.  Yay!
         ld de, PLAYER_WON_MESSAGE
-        call show_msg
+        call bios_output_string
         call turns_function
         jp 0x0000
 
 not_won:
         ; 3. show the prompt
         ld de, prompt_message
-        call show_msg
+        call bios_output_string
 
         ; 4. Erase our input buffer.
         ld hl, INPUT_BUFFER+2
@@ -226,7 +226,7 @@ not_won:
 
         ld (hl), 0              ; reset the count
         ld de, ship_closer_msg  ; show the message
-        call show_msg
+        call bios_output_string
 
         jp ship_warning_over
 
@@ -281,7 +281,7 @@ ship_warning_over:
 no_handler:
         ; Show the user that their command wasn't understood.
         ld de, invalid_msg
-        call show_msg
+        call bios_output_string
 
         ; Did we get eaten?
         call maybe_grue_death
@@ -435,14 +435,7 @@ de_delay_loop:
 
        ret
 
-;
-; Show a message, terminated with "$"
-;
-; Address in DE.
-;
-show_msg:
-        call bios_output_string
-        ret
+
 
 
 
@@ -858,12 +851,12 @@ maybe_grue_death:
 
         call show_dots
         ld de, grue_message
-        call show_msg
+        call bios_output_string
         ret
 
 death_by_grue_grue:
         ld de, you_were_eaten
-        call show_msg
+        call bios_output_string
 
         ld hl,PLAYER_DEAD
         inc (hl)
@@ -976,7 +969,7 @@ input_second_term_end:
 ;
 bad_language_function:
         ld de, BAD_LANGUAGE_MSG
-        jp show_msg
+        jp bios_output_string
 
 
 
@@ -998,7 +991,7 @@ down_function:
         ; fall-through other options will show "NO DOWN"
 no_down:
         ld de, no_down_msg
-        call show_msg
+        call bios_output_string
         ret
 
 down_on_top_floor:
@@ -1015,7 +1008,7 @@ down_on_ground_floor:
         jr z, down_found_trap
 
         ld de, failed_find_trapdoor_open_msg
-        call show_msg
+        call bios_output_string
         ret
 down_found_trap:
 
@@ -1090,7 +1083,7 @@ drop_function:
         jp z, drop_object
 
         ld de, DROP_WHAT_MSG
-        call show_msg
+        call bios_output_string
         ret
 
 drop_object:
@@ -1104,7 +1097,7 @@ drop_object:
         ; if we didn't find it in the current location or inventory
         ; then we're not carrying it.
         ld de, not_carrying_item_msg
-        call show_msg
+        call bios_output_string
         ret
 
 drop_found_it:
@@ -1143,7 +1136,7 @@ drop_found_it:
         or e
         jr nz, drop_invoke_handler
         ld de, you_drop_it
-        call show_msg
+        call bios_output_string
         ret
 
 drop_invoke_handler:
@@ -1176,7 +1169,7 @@ examine_function:
         jp z, examine_object
 
         ld de, EXAMINE_WHAT_MSG
-        call show_msg
+        call bios_output_string
         ret
 
 examine_object:
@@ -1190,7 +1183,7 @@ examine_object:
         jp z,examine_found_it
 
         ld de, item_not_present_msg
-        call show_msg
+        call bios_output_string
         ret
 
 examine_found_it:
@@ -1229,7 +1222,7 @@ show_ext_desc:
         ld d,(hl)
 
         ; show it
-        call show_msg
+        call bios_output_string
         ret
 
 
@@ -1248,7 +1241,7 @@ go_function:
 
 go_unknown:
         ld de, GO_WHERE_MSG
-        call show_msg
+        call bios_output_string
         ret
 
 go_somewhere:
@@ -1284,7 +1277,7 @@ call_function:
 
         ; not in the phone-room?  Show an error and return
         ld de, NO_PHONE_HERE
-        call show_msg
+        call bios_output_string
         ret
 
 call_proceed:
@@ -1294,7 +1287,7 @@ call_proceed:
 
         ; missing person
         ld de, CALL_WHO_MSG
-        call show_msg
+        call bios_output_string
         ret
 
 call_person:
@@ -1311,7 +1304,7 @@ next_person_test:
         ; show the error-message and return
         pop de
         ld de, call_unknown_msg
-        call show_msg
+        call bios_output_string
         ret
 
         ; OK we've got an entry
@@ -1352,7 +1345,7 @@ skip_string2:
         ld e, (hl)
         inc hl
         ld d, (hl)
-        call show_msg
+        call bios_output_string
         ret
 
 ;
@@ -1370,7 +1363,7 @@ get_function:
         jp z, get_object
 
         ld de, GET_WHAT_MSG
-        call show_msg
+        call bios_output_string
         ret
 
 get_object:
@@ -1382,7 +1375,7 @@ get_object:
         jp z,get_found_it
 
         ld de, item_not_present_msg
-        call show_msg
+        call bios_output_string
         ret
 
 get_found_it:
@@ -1427,7 +1420,7 @@ take_as_normal:
         jr z, get_found_it_take
 
         ld de, cant_take_that_msg
-        call show_msg
+        call bios_output_string
         ret
 
 get_found_it_take:
@@ -1458,7 +1451,7 @@ make_trapdoor_visible:
         jp z, place_trapdoor
 
         ld de, failed_find_trapdoor_msg
-        call show_msg
+        call bios_output_string
         ret
 
 place_trapdoor:
@@ -1492,7 +1485,7 @@ place_trapdoor:
 ;
 help_function:
         ld de, HELP_MSG
-        call show_msg
+        call bios_output_string
         ld de,command_table
 help_function_again: ; have we run out of commands?
         ld a, (de) ; length of string
@@ -1521,7 +1514,7 @@ help_func_loop:  ; copy the command-name to the buffer
         jr z, help_skip_this
         call show_tab
         ld de, TMP_BUFFER
-        call show_msg
+        call bios_output_string
 
 help_skip_this:
         pop de
@@ -1541,12 +1534,12 @@ inventory_function:
         jp z, inventory_show_items      ; Yes.  Go show
 
         ld de,inventory_empty_message   ; Otherwise "Carrying nothing"
-        call show_msg
+        call bios_output_string
         ret
 
 inventory_show_items:
         ld de,you_carrying_message
-        call show_msg
+        call bios_output_string
 
         ;
         ; We know there are items being carried, look for them
@@ -1581,7 +1574,7 @@ inventory_test_item:
 
         PUSH_ALL
           call show_tab
-          call show_msg
+          call bios_output_string
           call show_newline
         POP_ALL
 
@@ -1652,7 +1645,7 @@ look_function:
 
 look_at_environment:
         ld de,LOOK_FUNCTION_PREFIX
-        call show_msg
+        call bios_output_string
         ld hl, CURRENT_LOCATION  ; get current location
         ld a, (hl)
         ld b, a                  ; multiply by the length of each entry
@@ -1668,7 +1661,7 @@ look_function_show:
         ld d, (hl)
         inc hl
         push hl
-        call show_msg
+        call bios_output_string
         call show_newline
         call show_newline
         pop hl
@@ -1692,7 +1685,7 @@ look_function_show:
         ret z
 look_show_extended:
         push hl
-        call show_msg
+        call bios_output_string
         pop hl
 
         ld a, 1
@@ -1706,7 +1699,7 @@ look_show_extended:
 
         ; Show "You see .."
         ld de,you_see_message
-        call show_msg
+        call bios_output_string
 
         ;
         ; OK at this point we have looked at the room, and
@@ -1757,7 +1750,7 @@ look_item_loop:
 
         PUSH_ALL
           call show_tab
-          call show_msg
+          call bios_output_string
           call show_newline
         POP_ALL
 item_not_present:
@@ -1795,7 +1788,7 @@ magic_function:
 
         ; magic four
         ld de, magic_four_msg
-        call show_msg
+        call bios_output_string
 
         ; you're dead
         ld hl, PLAYER_DEAD
@@ -1803,15 +1796,15 @@ magic_function:
         ret
 magic_one:
         ld de, magic_one_msg
-        call show_msg
+        call bios_output_string
         ret
 magic_two:
         ld de, magic_two_msg
-        call show_msg
+        call bios_output_string
         ret
 magic_three:
         ld de, magic_three_msg
-        call show_msg
+        call bios_output_string
         ret
 
 
@@ -1824,7 +1817,7 @@ magic_three:
 ;
 quit_function:
         ld de, QUIT_MSG
-        call show_msg
+        call bios_output_string
         call turns_function
         jp 0x0000
 
@@ -1837,7 +1830,7 @@ quit_function:
 sleep_function:
 
        ld de, SLEEP_START_MSG
-       call show_msg
+       call bios_output_string
 
        call show_dots
 
@@ -1848,7 +1841,7 @@ sleep_function:
        ld (hl),a
 
        ld de, SLEEP_END_MSG
-       call show_msg
+       call bios_output_string
        ret
 
 
@@ -1860,12 +1853,12 @@ sleep_function:
 turns_function:
         call show_newline
         ld de, PLAYER_TURN_COUNT
-        call show_msg
+        call bios_output_string
         ld hl, TURN_COUNT
         ld a, (hl)
         call show_a_register
         ld de, PLAYER_TURN_COUNT_END
-        call show_msg
+        call bios_output_string
         ret
 
 
@@ -1880,7 +1873,7 @@ use_function:
         jp z, use_object
 
         ld de, USE_WHAT_MSG
-        call show_msg
+        call bios_output_string
         ret
 
 use_object:
@@ -1892,7 +1885,7 @@ use_object:
         jp z, use_found_object
 
         ld de, item_not_present_msg
-        call show_msg
+        call bios_output_string
         ret
 
 use_found_object:
@@ -1920,7 +1913,7 @@ use_found_object:
         ret
 use_is_futile:
         ld de, use_generic
-        call show_msg
+        call bios_output_string
         ret
 
 
@@ -1970,12 +1963,12 @@ up_on_middle_floor:
 
         ; Show the successful result
         ld de, meteor_saves_the_day
-        call show_msg
+        call bios_output_string
         ret
 
 no_up:
         ld de, no_up_msg
-        call show_msg
+        call bios_output_string
         ret
 
 up_on_dark_room:
@@ -1994,12 +1987,12 @@ up_on_basement_floor:
 
 show_newline:
         ld de, NEWLINE
-        jp show_msg
+        jp bios_output_string
 
 show_tab:
         PUSH_ALL
         ld de, TAB
-        call show_msg
+        call bios_output_string
         POP_ALL
         ret
 
@@ -2011,7 +2004,7 @@ show_tab:
 ;
 wait_function:
         ld de, WAIT_CMD_MSG
-        call show_msg
+        call bios_output_string
         ret
 
 ; }
@@ -2067,7 +2060,7 @@ drop_mirror_fn:
 
         ; Show the drop message
         ld de, MIRROR_DROP_FUN
-        call show_msg
+        call bios_output_string
         ret
 
 
@@ -2113,13 +2106,13 @@ examine_rug_fn:
         inc hl
         ld d,(hl)
 
-        call show_msg
+        call bios_output_string
         ret
 
 rug_on_ground:
 
         ld de, rug_detail_msg
-        call show_msg
+        call bios_output_string
         call make_trapdoor_visible
         ret
 
@@ -2150,7 +2143,7 @@ examine_desk_fn:
         jr z, meteor_hidden
 
         ld de, item_9_long
-        call show_msg
+        call bios_output_string
         ret
 
 meteor_hidden:
@@ -2164,11 +2157,11 @@ meteor_hidden:
 
         ; desk description
         ld de, item_9_long
-        call show_msg
+        call bios_output_string
 
         ; desk addendum
         ld de, desk_has_meteor
-        call show_msg
+        call bios_output_string
         ret
 
 
@@ -2195,7 +2188,7 @@ take_meteor_fn:
         jr nz, take_meteor
 
         ld de,item_not_present_msg
-        call show_msg
+        call bios_output_string
         ret
 
 take_meteor:
@@ -2270,7 +2263,7 @@ take_rug_fn:
 
         ; show a message telling the user about the trapdoor.
         ld de, rug_taken_msg
-        call show_msg
+        call bios_output_string
 
         ; And make the trapdoor visible
         call make_trapdoor_visible
@@ -2307,7 +2300,7 @@ use_book_fn:
         ld d,(hl)
 
         ; show it
-        call show_msg
+        call bios_output_string
         ret
 
 
@@ -2325,7 +2318,7 @@ use_torch_fn:
         jp z,use_torch_found_t
 
         ld de, failed_find_torch_msg
-        call show_msg
+        call bios_output_string
         ret
 use_torch_found_t:
 
@@ -2354,7 +2347,7 @@ use_torch_found_t:
 
         pop af; fixup
         ld de, failed_find_torch_lit_msg
-        call show_msg
+        call bios_output_string
         ret
 
 use_torch_found_t2:
@@ -2375,7 +2368,7 @@ use_torch_found_t2:
 
         ; Show the message
         ld de, TORCH_ON_MSG
-        call show_msg
+        call bios_output_string
 
         ; If you're in the dark-place we'll now warp you to the
         ; normal basement.
@@ -2387,7 +2380,7 @@ use_torch_found_t2:
 
         ; show that you can see where you are
         ld de,NOW_YOU_SEE
-        call show_msg
+        call bios_output_string
 
         ; show the location
         FAKE_LOOK
@@ -2411,7 +2404,7 @@ use_trapdoor_fn:
         jp z,use_trapdoor_found_t
 
         ld de, failed_find_trapdoor_msg
-        call show_msg
+        call bios_output_string
         ret
 use_trapdoor_found_t:
 
@@ -2431,7 +2424,7 @@ use_trapdoor_found_t:
         jr z, open_trapdoor_present
 
         ld de, item_not_present_msg
-        call show_msg
+        call bios_output_string
         ret
 
 open_trapdoor_present:
@@ -2452,7 +2445,7 @@ open_trapdoor_present:
         jp z,use_trapdoor_found_t2
 
         ld de, failed_find_trapdoor_open_msg
-        call show_msg
+        call bios_output_string
         ret
 
 use_trapdoor_found_t2:
@@ -2476,7 +2469,7 @@ use_trapdoor_found_t2:
 
         ; Show the message
         ld de, TRAPDOOR_OPEN_MSG
-        call show_msg
+        call bios_output_string
         ret
 
 
@@ -2493,7 +2486,7 @@ use_generator_fn:
         jp z,use_generator_found_t
 
         ld de, failed_find_generator_msg
-        call show_msg
+        call bios_output_string
         ret
 
 use_generator_found_t:
@@ -2505,14 +2498,14 @@ use_generator_found_t:
         jr z, use_generator_won_fn
 
         ld de, use_gen_location
-        call show_msg
+        call bios_output_string
         ret
 use_generator_won_fn:
         ld hl, PLAYER_WON
         ld (hl),1
 
         ld de, use_generator_won
-        call show_msg
+        call bios_output_string
         ret
 
 ;}

--- a/game.z80
+++ b/game.z80
@@ -2510,6 +2510,8 @@ use_generator_won_fn:
 
 ;}
 
+include "bios.z80"
+
 
 
 
@@ -3367,7 +3369,5 @@ TMP_BUFFER_LEN: EQU 50
 ; launch - if that support is enabled.
 ;
 end_of_source:
-
-include "bios.z80"
 
 END ENTRYPOINT

--- a/game.z80
+++ b/game.z80
@@ -2704,7 +2704,6 @@ THE:
 ON:
         db " ON "
 usage_message:
-        db 0x0a, 0x0d
 IF SPECTRUM
         db "                                "
         db "                                "
@@ -2716,6 +2715,7 @@ IF SPECTRUM
         db "                                "
         db " Press any key to start.        $"
 ELSE
+        db 0x0a, 0x0d
         db "        .n.         ", 27, "[1;4mThe lighthouse of doom", 27, "[1;0m",  0x0a, 0x0d
         db "       /___\\ ", 0x0a, 0x0d
         db "       [|||]        ", 0x0a, 0x0d

--- a/game.z80
+++ b/game.z80
@@ -46,16 +46,6 @@
 
 
 
-; BIOS entry-point
-BDOS_ENTRY_POINT:    EQU 5
-
-; BIOS functions we call
-BDOS_CHARACTER_READ:          EQU 0x01
-BDOS_OUTPUT_STRING:           EQU 0x09
-BDOS_READ_INPUT:              EQU 0x0A
-BDOS_OUTPUT_SINGLE_CHARACTER: EQU 0x02
-
-
 ; Game over if you don't win in this many turns
 MAX_TURN_LIMIT: EQU 100
 
@@ -111,7 +101,11 @@ MACRO POP_ALL
         ;
         ;     https://en.wikipedia.org/wiki/Zero_page_(CP/M)
         ;
-        ORG 100h
+        ORG ENTRYPOINT
+
+        ; Call system-specific setup routine before we
+        ; do anything else.
+        call bios_init
 
         ;
         ; Our game can be compiled with optional "encryption", which uses
@@ -150,16 +144,15 @@ enc_end:
 ENDIF
 
         ; Clear the screen
-        call cls_function
+        call bios_clear_screen
 
         ; Present the game intro-text.
         ld de, usage_message
         call show_msg
 
         ; Pause for input here.
-        ld c,BDOS_CHARACTER_READ
-        call BDOS_ENTRY_POINT
-        call cls_function
+        call bios_await_keypress
+        call bios_clear_screen
 
         ; Show the starting-location.
         call show_newline
@@ -222,8 +215,7 @@ not_won:
 
         ; 5. Read a line of input from the player.
         ld de, INPUT_BUFFER
-        ld c, BDOS_READ_INPUT
-        call BDOS_ENTRY_POINT
+        call bios_read_input
 
         ; Every five turns we show a message about the ship.
         ;
@@ -436,9 +428,8 @@ de_delay_loop:
          jr nz, hl_delay_loop
 
          PUSH_ALL
-         ld c, BDOS_OUTPUT_SINGLE_CHARACTER
          ld e, "."
-         call BDOS_ENTRY_POINT
+         call bios_output_character
          POP_ALL
        djnz hl_delay
 
@@ -447,11 +438,10 @@ de_delay_loop:
 ;
 ; Show a message, terminated with "$"
 ;
-; Address in DE
+; Address in DE.
 ;
 show_msg:
-        ld c, BDOS_OUTPUT_STRING
-        call BDOS_ENTRY_POINT
+        call bios_output_string
         ret
 
 
@@ -496,9 +486,8 @@ Num2:	inc	a
 
         PUSH_ALL
 
-        ld c, BDOS_OUTPUT_SINGLE_CHARACTER
         ld e, a
-        call BDOS_ENTRY_POINT
+        call bios_output_character
 
         POP_ALL
 	ret
@@ -990,14 +979,6 @@ bad_language_function:
         jp show_msg
 
 
-
-;
-; Command-Handler CLS
-;
-;  Clear the screen
-cls_function:
-        ld de, CLS_MSG
-        jp show_msg
 
 ;
 ; Command-Handler DOWN
@@ -1629,6 +1610,7 @@ inv_item_not_carried:
 ; If we see "LOOK AT XXX" then we replace the command with "EXAMINE YYYY"
 ;
 look_function:
+
         ld de, LOOK_AT                ;; "LOOK AT "
         ld b, 7                       ;; strlen("LOOK_AT ")
         ld hl, INPUT_BUFFER+2
@@ -2538,7 +2520,6 @@ use_generator_won_fn:
 
 
 
-
 ;********************************************************************
 ; Data / State Storage
 ;********************************************************************
@@ -2636,10 +2617,6 @@ failed_find_torch_lit_msg:
         db 0x0a, 0x0d, "BUG:Failed to find the lit torch.", 0x0a, 0x0d, "$"
 failed_find_generator_msg:
         db 0x0a, 0x0d, "BUG:Failed to find the generator.", 0x0a, 0x0d, "$"
-CLS_MSG:
-        db 27, "[2J"            ; "clear"
-        db 27, "[H"             ; "home"
-        db "$"
 use_gen_location:
         db 0x0a, 0x0d, "You cannot see anywhere to connect the generator to."
         db 0x0a, 0x0d, "$"
@@ -2728,7 +2705,17 @@ ON:
         db " ON "
 usage_message:
         db 0x0a, 0x0d
-
+IF SPECTRUM
+        db "                                "
+        db "                                "
+        db "                                "
+        db "The lighthouse of Doom          "
+        db "                                "
+        db "            (c) 2022 Steve Kemp "
+        db "                                "
+        db "                                "
+        db " Press any key to start.        $"
+ELSE
         db "        .n.         ", 27, "[1;4mThe lighthouse of doom", 27, "[1;0m",  0x0a, 0x0d
         db "       /___\\ ", 0x0a, 0x0d
         db "       [|||]        ", 0x0a, 0x0d
@@ -2760,6 +2747,7 @@ include "version.z80"
         db "Any references to the Paw Patrol are entirely deliberate."
         db 0x0a, 0x0d, 0x0a, 0x0d
         db "Press any key to start.$"
+ENDIF
 
 PLAYER_DEAD_MESSAGE:
         db 0x0a, 0x0d, "Unfortunately you took too long to fix the broken light."
@@ -2949,7 +2937,7 @@ item_16_long: db "The dog-basket is a faded red colour, and covered with dog-hai
 ;
 command_table:
         DEFB 3, 'CLS', 1
-          DEFW cls_function
+          DEFW bios_clear_screen
         DEFB 4, 'DOWN', 0
           DEFW down_function
         DEFB 4, 'DROP', 0
@@ -3386,3 +3374,7 @@ TMP_BUFFER_LEN: EQU 50
 ; launch - if that support is enabled.
 ;
 end_of_source:
+
+include "bios.z80"
+
+END ENTRYPOINT


### PR DESCRIPTION
This pull-request will close #27, once complete, by porting the game to the ZX Spectrum.

The initial commits do the obvious things:

* Added a `bios.z80` file to contain the platform-specific code.
  * This abstracts the clearing of the screen, prompting for input, and outputing strings and characters. 
* The Makefile was updated to add a new Spectrum-specific target.

I've reworded the text of the introduction screen, but the wrapping of text is going to be a nightmare as the spectrum has a much shorter/narrower display.

Outstanding tasks:

* [x] Allow editing/canceling input.
* [x] Handle scrolling properly.
    * [x] Either keep track of characters, and scroll ourselves, or
    * [x] Clear the screen after reading input.
* [x] Improve the display of the prompt for the spectrum.
* [x] Tweak the grue-delay for the spectrum, the timing is all wrong.