### PR TITLE
29 index

### DIFF
--- a/game.z80
+++ b/game.z80
@@ -893,6 +893,8 @@ gibn_item_available:
 gibn_found_it:
         pop bc
         pop hl
+        push hl
+        pop ix      ; IX points to the item, as well as HL
         xor a
         ret
 
@@ -919,15 +921,13 @@ maybe_grue_death:
         cp 0
         ret nz
 
-        ; Get the item-state, we use that to count how
-        ; many times we've been down here, and increase
-        ; the count too.
-        push hl
-        ld de, ITEM_TABLE_STATE_OFFSET
-        add hl,de
-        ld a, (hl)
-        inc (hl)
-        pop hl
+        ; Once we've found the item IX will point to the
+        ; entry (as well as HL).
+        ;
+        ; Get the item state using that index register,
+        ; after increasing it.
+        inc  (IX +  ITEM_TABLE_STATE_OFFSET)
+        ld a,(IX + ITEM_TABLE_STATE_OFFSET)
 
         cp MAX_GRUE_EXPOSURE
         jr nc, death_by_grue_grue
@@ -1088,10 +1088,12 @@ down_on_ground_floor:
         ; Find the item, and get it's state.
         ld hl, item_11_name
         call get_item_by_name
-        ; find the offset for the state, and then get it.
-        ld de, ITEM_TABLE_STATE_OFFSET
-        add hl,de
-        ld a, (hl)
+
+        ; Once we've found the item IX will point to the
+        ; entry (as well as HL).
+        ;
+        ; Get the item state using the index register.
+        ld a, (IX+ITEM_TABLE_STATE_OFFSET)
 
         cp TRAPDOOR_STATE_OPEN
         jr nz, no_down ; not open?  Then we can't go down
@@ -1126,21 +1128,18 @@ user_has_lit_torch:
         ld hl, item_3_name
         call get_item_by_name
 
-        ; Get the location in A, leaving HL pointing to the start of the object
-        push hl
-        ld de, ITEM_TABLE_LOCATION_OFFSET
-        add hl,de
-        ld a, (hl)
-        pop hl
+        ; Once we've found the item IX will point to the
+        ; entry (as well as HL).
+        ;
+        ; Get the location using the index register.
+        ld a, (IX+ITEM_TABLE_LOCATION_OFFSET)
 
         ; Are we carrying the item?
-        cp 255
+        cp ITEM_CARRIED
         jr nz, user_not_got_torch
 
-        ; OK HL still points to the start of the object get the state
-        ld de, ITEM_TABLE_STATE_OFFSET
-        add hl,de
-        ld a, (hl)
+        ; OK now see if the torch is lit
+        ld a, (IX+ITEM_TABLE_STATE_OFFSET)
 
         ; Is it lit?
         cp TORCH_STATE_LIT
@@ -1467,15 +1466,12 @@ get_found_it:
         ; HL points to the start of the item-entry of the object
         ; the user tried to take.
 
-        ; HL points to the start of the entry
-        ; get the pointer to the custom take-function, in DE, leaving HL alone
-        push hl
-        ld de, ITEM_TABLE_TAKE_OFFSET
-        add hl,de
-        ld e, (hl)
-        inc hl
-        ld d, (hl)
-        pop hl
+        ; IX points to the start of the entry for the object.
+        ;
+        ; Find the name of the custom take-handler, if any, using
+        ; the index-register.
+        ld e, (IX+ITEM_TABLE_TAKE_OFFSET)
+        ld d, (IX+ITEM_TABLE_TAKE_OFFSET+1)
 
         ; Is there a custom function?
         ld a, d
@@ -1490,15 +1486,9 @@ get_found_it:
 
 take_as_normal:
 
-        ; Get the collectable property of the object, leaving HL
-        ; pointing to the start of the object
-        push hl
-        push de
-        ld de, ITEM_TABLE_COLLECTABLE_OFFSET
-        add hl,de
-        ld a, (hl)
-        pop de
-        pop hl
+        ; Get the collectable property of the object, using
+        ; the index register.
+        ld a, (IX+ITEM_TABLE_COLLECTABLE_OFFSET)
 
         ; is this item collectable?
         cp 1
@@ -1510,15 +1500,9 @@ take_as_normal:
 
 get_found_it_take:
 
-        ; HL still points to the start of the item entry
-        ; change the location to be in the player's possession
-        push hl
-        push de
-        ld de, ITEM_TABLE_LOCATION_OFFSET
-        add hl,de
-        ld (hl), ITEM_CARRIED
-        pop de
-        pop hl
+        ; Change the location of the object to be within the
+        ; players possession.
+        ld (IX+ITEM_TABLE_LOCATION_OFFSET),ITEM_CARRIED
 
         ; Now we've taken the item show the users (updated)
         ; inventory.

--- a/game.z80
+++ b/game.z80
@@ -56,7 +56,7 @@ MAX_GRUE_EXPOSURE: EQU 3
 ; so they may be examined.
 ;
 ; Each object has a description, a state, and a location, along with
-; dedicated handler-functions.
+; a collection of dedicated handler-functions.
 ;
 ; Here we define some state attributes for a couple of special objects
 ; which eases maintainance.
@@ -65,11 +65,25 @@ MAX_GRUE_EXPOSURE: EQU 3
 TORCH_STATE_UNLIT:      EQU 0
 TORCH_STATE_LIT:        EQU 1
 
-; 2. Trapdoor may be hidden, visible, or opened.
-;
-; hiding is handled via the location for historical reasons.
+; 2. The trapdoor may be open or closed.
+;    [It may also be invisible, but that is handled via another mechanism]
 TRAPDOOR_STATE_CLOSED:  EQU 0
 TRAPDOOR_STATE_OPEN:    EQU 1
+
+
+; We have a bunch of tables defined later, one for the locations,
+; one for the available commands, and one for the items.
+;
+; Each item has a byte which contains the "location" (i.e. index
+; into the location-map).  Two locations are special:
+;
+; A location of 0xff means the player is carrying the item.
+; A location of 0xfe means the item is available, but invisible.
+;
+; Define helpers for these values.
+;
+ITEM_CARRIED: EQU 0xff
+ITEM_INVISIBLE: EQU 0xfe
 
 
 
@@ -262,10 +276,10 @@ not_won:
         ld de, INPUT_BUFFER
         call bios_read_input
 
-        ; Every five turns we show a message about the ship.
+        ; Every ten turns we show a message about the ship.
         ld hl, SHIP_WARNING
         ld a, (hl)              ; get the value
-        cp 5                    ; five turns?
+        cp 10                   ; ten turns?
         jr nz, no_ship_warning  ; nope?  Do nothing
 
         ld (hl), 0              ; reset the count
@@ -768,15 +782,16 @@ item_not_present_loop:
 
 
 ;
-; Helper function.  Get an item by name.
+; Helper function to return an item, by name.
 ;
-; On entry the name of the item to be found  will be stored in HL.
+; This is used a lot because the item-entries contain a series of
+; pointers for various purposes - handlers to be invoked for object-specific
+; behaviour, the location of the object within our world-map, and
+; a byte representing per-item state.
 ;
-; On exit A will be 00 if all is OK, and HL will point to the item.
-;
+; On entry the name of the item to be found will be stored in HL.
+; On exit A will be 00 if all is OK, and both IX & HL will point to the item.
 ; On exit A will be ff if there was a failure.
-;
-; This is a bit hairy, but not too bad.
 ;
 get_item_by_name:
 
@@ -831,9 +846,9 @@ gibn_item_loop:
         ; Is this object carried, in the current location, or
         ; otherwise available?
         ld a,(hl)
-        cp 0xFF ; 0xff means the item is being carried
+        cp ITEM_CARRIED ; 0xff means the item is being carried
         jr z, gibn_item_carried
-        cp 0xFE ; 0xfe means the item can be found/used/examined
+        cp ITEM_INVISIBLE ; The item can be found/used/examined
         jr z, gibn_item_available
         push hl
         ld hl, CURRENT_LOCATION
@@ -961,7 +976,7 @@ player_has_objects_loop:
 
         ; If the location is 0xff then the player is carrying
         ; something.
-        cp 0xff
+        cp ITEM_CARRIED
         jr nz, player_not_carrying_loop
 
         ; Report success
@@ -1501,7 +1516,7 @@ get_found_it_take:
         push de
         ld de, ITEM_TABLE_LOCATION_OFFSET
         add hl,de
-        ld (hl), 0xff
+        ld (hl), ITEM_CARRIED
         pop de
         pop hl
 
@@ -1639,7 +1654,7 @@ inventory_test_item:
         pop de
         pop hl
 
-        cp 0xff ; 0xff means the item is being carried
+        cp ITEM_CARRIED ; 0xff means the item is being carried
         jr nz, inv_item_not_carried
 
         PUSH_ALL
@@ -2302,7 +2317,7 @@ examine_rug_fn:
         pop hl
 
         ; Is the item in your possessions?
-        cp 0xff
+        cp ITEM_CARRIED
         jr nz, rug_on_ground
 
         ; The rug must be in your possession, just show the extended
@@ -2408,7 +2423,7 @@ take_meteor:
         push hl
         ld de, ITEM_TABLE_LOCATION_OFFSET
         add hl,de
-        ld  (hl), 0xff
+        ld  (hl), ITEM_CARRIED
         pop hl
 
         ; Now we've taken the item show the users (updated)
@@ -2433,7 +2448,7 @@ take_rug_fn:
         push hl
         ld de, ITEM_TABLE_LOCATION_OFFSET
         add hl,de
-        ld (hl), 0xff
+        ld (hl), ITEM_CARRIED
         pop hl
 
         ; Taking the rug should only trigger this behaviour once.
@@ -3404,13 +3419,13 @@ item_first:
         DEFW item_2_name  ; mirror-broken
         DEFW item_2_desc
         DEFW item_2_long
-        DEFB 0,0          ; No take function
-        DEFB 0,0          ; No drop function
-        DEFB 0,0          ; No examine function
-        DEFB 0,0          ; No use function
-        DEFB 0            ; item state
-        DEFB 1            ; this item can be picked up
-        DEFB 0xFe         ; not visible anywhere
+        DEFB 0,0            ; No take function
+        DEFB 0,0            ; No drop function
+        DEFB 0,0            ; No examine function
+        DEFB 0,0            ; No use function
+        DEFB 0              ; item state
+        DEFB 1              ; this item can be picked up
+        DEFB ITEM_INVISIBLE ; not visible anywhere
 
         DEFW item_3_name  ; torch
 torch_item_desc:
@@ -3502,7 +3517,7 @@ trapdoor_edesc:
         DEFW use_trapdoor_fn       ; open function
         DEFB TRAPDOOR_STATE_CLOSED ; item state
         DEFB 0                     ; this item cannot be picked up
-        DEFB 0xFE                  ; hidden until the rug is moved
+        DEFB ITEM_INVISIBLE        ; hidden until the rug is moved
 
         DEFW item_13_name ; meteor
         DEFW item_13_desc
@@ -3513,7 +3528,7 @@ trapdoor_edesc:
         DEFB 0,0            ; No use function
         DEFB 0              ; item state
         DEFB 0              ; this item cannot be picked up
-        DEFB 0xFE           ; hidden until the desk is examined
+        DEFB ITEM_INVISIBLE ; hidden until the desk is examined
 
         DEFW item_14_name    ; room
         DEFB 0,0             ; NO DESCRIPTION - hidden item
@@ -3524,7 +3539,7 @@ trapdoor_edesc:
         DEFB 0,0             ; No use function
         DEFB 0               ; item state
         DEFB 0               ; this item cannot be picked up
-        DEFB 0xFE            ; hidden.
+        DEFB ITEM_INVISIBLE  ; hidden.
 
         DEFW item_15_name    ; grue
         DEFB 0,0             ; NO DESCRIPTION - hidden item
@@ -3535,7 +3550,7 @@ trapdoor_edesc:
         DEFB 0,0             ; No use function
         DEFB 0               ; item state
         DEFB 0               ; this item cannot be picked up
-        DEFB 0xFE            ; hidden.
+        DEFB ITEM_INVISIBLE  ; hidden.
 
         DEFW item_16_name     ; dog-basket
         DEFB 0,0              ; NO DESCRIPTION - hidden item

--- a/game.z80
+++ b/game.z80
@@ -1565,8 +1565,6 @@ help_skip_this:
 ;
 ; Command-handler INVENTORY
 ;
-; TODO: Use index-register
-;
 inventory_function:
         call player_has_objects         ; is the player carrying:
         cp 0
@@ -1581,49 +1579,39 @@ inventory_show_items:
         call bios_output_string
 
         ;
-        ; We know there are items being carried, look for them
+        ; We know there are items being carried, so now we'll loop
+        ; over them and print them out appropriately.
         ;
-        ld hl, items
+        ld IX, items
+        ld DE, ITEM_ENTRY_LENGTH
         ld b, ITEM_COUNT
 inventory_test_item:
 
-        ; HL points to the item-table
-        ; Get the description of the object in DE, but leaving
-        ; HL pointing to the start of the item's entry.
-        push hl
-        ld de, ITEM_TABLE_DESCRIPTION_OFFSET
-        add hl,de
-        ld e, (hl)
-        inc hl
-        ld d, (hl)
-        pop hl
+        ; Get the location of the object.
+        ld a, (IX+ITEM_TABLE_LOCATION_OFFSET)
 
-        ; Get the location of the object in A, but leaving
-        ; HL pointing to the start of the item's entry.
-        push hl
-        push de
-        ld de, ITEM_TABLE_LOCATION_OFFSET
-        add hl,de
-        ld a, (hl)
-        pop de
-        pop hl
-
+        ; Is this carried?
         cp ITEM_CARRIED ; 0xff means the item is being carried
         jr nz, inv_item_not_carried
 
+        ; OK the item is carried, show it out.
         PUSH_ALL
+
+          ; Show a tab
           call show_tab
+
+          ; show the item
+          ld e,(IX + ITEM_TABLE_DESCRIPTION_OFFSET)
+          ld d,(IX + ITEM_TABLE_DESCRIPTION_OFFSET+1)
           call bios_output_string
+
+          ; then a newline
           call show_newline
         POP_ALL
 
 inv_item_not_carried:
-        ; Since we have HL pointing to an entry we can move to the next
-        ; just by adding the length of the table-item.
-        push de
-        ld de, ITEM_ENTRY_LENGTH
-        add hl,de
-        pop de
+        ; bump to the next item
+        add ix,de
         djnz inventory_test_item
         ret
 
@@ -1640,8 +1628,6 @@ inv_item_not_carried:
 ;   LOOK AT XXX
 ;
 ; If we see "LOOK AT XXX" then we replace the command with "EXAMINE YYYY"
-;
-; TODO: Use index-register
 ;
 look_function:
 
@@ -1749,30 +1735,13 @@ look_show_extended:
         ; Walk over the list of items - and show any which
         ; are present in this room.
         ;
-        ld hl, items
+        ld IX, items
         ld b, ITEM_COUNT
+
 look_item_loop:
 
-        ; HL points to the item-table
-        ; Get the description of the object in DE, but leaving
-        ; HL pointing to the start of the item's entry.
-        push hl
-        ld de, ITEM_TABLE_DESCRIPTION_OFFSET
-        add hl,de
-        ld e, (hl)
-        inc hl
-        ld d, (hl)
-        pop hl
-
-        ; Get the location of the object in C, but leaving
-        ; HL pointing to the start of the item's entry.
-        push hl
-        push de
-        ld de, ITEM_TABLE_LOCATION_OFFSET
-        add hl,de
-        ld c, (hl)
-        pop de
-        pop hl
+        ; Get the location of the object.
+        ld c, (IX+ITEM_TABLE_LOCATION_OFFSET)
 
         ; Get the current location
         push hl
@@ -1784,7 +1753,11 @@ look_item_loop:
         cp c
         jr nz, item_not_present
 
-        ; Is the description empty?  Then it is hidden.
+        ; Get the description of the object in DE
+        ld e,(IX+ITEM_TABLE_DESCRIPTION_OFFSET)
+        ld d,(IX+ITEM_TABLE_DESCRIPTION_OFFSET+1)
+
+        ; Is the description empty?  Then the item is hidden.
         ld a, d
         or e
         jr z, item_not_present
@@ -1797,10 +1770,8 @@ look_item_loop:
 item_not_present:
         ; Since we have HL pointing to an entry we can move to the next
         ; just by adding the length of the table-item.
-        push de
         ld de, ITEM_ENTRY_LENGTH
-        add hl,de
-        pop de
+        add IX,de
         djnz look_item_loop
         ret
 
@@ -2242,8 +2213,6 @@ examine_room_fn:
 ;    make the trapdoor appear
 ;
 ;  If the rug is in your posession just show the description
-;
-; TODO: Use the index register
 examine_rug_fn:
 
         ; Get the rug object
@@ -2251,11 +2220,7 @@ examine_rug_fn:
         call get_item_by_name
 
         ; Get the location which it appears
-        push hl
-        ld de, ITEM_TABLE_LOCATION_OFFSET
-        add hl,de
-        ld a,(hl)
-        pop hl
+        ld a,(IX+ITEM_TABLE_LOCATION_OFFSET)
 
         ; Is the item in your possessions?
         cp ITEM_CARRIED
@@ -2263,17 +2228,10 @@ examine_rug_fn:
 
         ; The rug must be in your possession, just show the extended
         ; description.
-        push de
-        ld de, ITEM_TABLE_EXT_DESCRIPTION_OFFSET
-        add hl, de
-        pop de
-
-        ; Get the pointer to the string
-        ld e,(hl)
-        inc hl
-        ld d,(hl)
-
+        ld e, (IX+ITEM_TABLE_EXT_DESCRIPTION_OFFSET)
+        ld d, (IX+ITEM_TABLE_EXT_DESCRIPTION_OFFSET+1)
         call bios_output_string
+
         ret
 
 rug_on_ground:
@@ -2290,21 +2248,16 @@ rug_on_ground:
 ;  If the meteor is hidden
 ;   it will become visible
 ;
-;  Otherwise you just see the desk
+;  Otherwise you just see the desk.
 ;
-; TODO: Use index-register
 examine_desk_fn:
 
         ; Get the meteor item
         ld hl, item_13_name
         call get_item_by_name
 
-        ; Get the state in A, leaving HL pointing to the start of the object
-        push hl
-        ld de, ITEM_TABLE_STATE_OFFSET
-        add hl,de
-        ld a, (hl)
-        pop hl
+        ; Get the state of the meteor
+        ld a, (IX+ITEM_TABLE_STATE_OFFSET)
 
         ; If the state of the meteor is hidden, then show it
         cp 0
@@ -2317,11 +2270,7 @@ examine_desk_fn:
 meteor_hidden:
 
         ; Update the state of the desk to show we've examined it
-        push hl
-        ld de, ITEM_TABLE_STATE_OFFSET
-        add hl,de
-        ld (hl), 1
-        pop hl
+        ld (IX+ITEM_TABLE_STATE_OFFSET), 1
 
         ; desk description
         ld de, item_9_long
@@ -2339,18 +2288,14 @@ meteor_hidden:
 ;
 ;  This is set by examine desk
 ;
-; TODO: Use index-register
 take_meteor_fn:
         ; Get the meteor item
         ld hl, item_13_name
         call get_item_by_name
 
-        ; Get the state in A, leaving HL pointing to the start of the object
-        push hl
-        ld de, ITEM_TABLE_STATE_OFFSET
-        add hl,de
-        ld a, (hl)
-        pop hl
+        ; Get the state of the meteor - we must have discovered
+        ; it by examining the desk before we can take it.
+        ld a, (IX + ITEM_TABLE_STATE_OFFSET)
 
         ; State is 0?
         cp 0
@@ -2361,13 +2306,8 @@ take_meteor_fn:
         ret
 
 take_meteor:
-
         ; update the object location to be in the player's posession
-        push hl
-        ld de, ITEM_TABLE_LOCATION_OFFSET
-        add hl,de
-        ld  (hl), ITEM_CARRIED
-        pop hl
+        ld (IX + ITEM_TABLE_STATE_OFFSET), ITEM_CARRIED
 
         ; Now we've taken the item show the users (updated)
         ; inventory.
@@ -2381,26 +2321,19 @@ take_meteor:
 ;
 ;  - AND you're in the basement
 ;
-; TODO: Use index-register
 take_rug_fn:
 
         ; Get the rug object
         ld hl, item_7_name
         call get_item_by_name
 
-        ; Update the location, so that we've taken it.
-        push hl
-        ld de, ITEM_TABLE_LOCATION_OFFSET
-        add hl,de
-        ld (hl), ITEM_CARRIED
-        pop hl
+        ; Move the rug into the player's possession.
+        ld (IX+ITEM_TABLE_LOCATION_OFFSET),ITEM_CARRIED
 
         ; Taking the rug should only trigger this behaviour once.
         ;
         ; Since we have a piece of state with each object we can use that.
-        ld de, ITEM_TABLE_STATE_OFFSET
-        add hl,de
-        ld a, (hl)
+        ld a, (IX + ITEM_TABLE_STATE_OFFSET)
 
         ; If the state contains non-zero we've done this
         ; before so we just show the inventory as we would
@@ -2409,7 +2342,7 @@ take_rug_fn:
         jr nz, get_rug_show_inv
 
         ; Store 1 in the state, so we don't do this again.
-        inc (hl)
+        ld (IX + ITEM_TABLE_STATE_OFFSET),1
 
         ; Is the trapdoor already present?  If so we don't need
         ; to do anything special.
@@ -2421,11 +2354,7 @@ take_rug_fn:
         ; get the location
         ; Get the location of the object in A, but leaving
         ; HL pointing to the start of the item's entry.
-        push hl
-        ld de, ITEM_TABLE_LOCATION_OFFSET
-        add hl,de
-        ld a, (hl)
-        pop hl
+        ld a, (IX+ITEM_TABLE_LOCATION_OFFSET)
 
         ; trapdoor in the basement?  No special action required
         cp 2

--- a/game.z80
+++ b/game.z80
@@ -725,57 +725,39 @@ we_found_the:
 ;
 items_are_present:
 
-        ; Point to the item-table, and get the count of objects
-        ld hl, items
+        ; Point to the item-table, and prepare to loop over the items
+        ld IX, items
+        ld DE, ITEM_ENTRY_LENGTH
         ld b, ITEM_COUNT
 
 look_item_loop_test:
 
+        ; Get the location of the object in C
+        ld c, (IX+ITEM_TABLE_LOCATION_OFFSET)
+
         ; Set A to the current location.
-        push hl
         ld hl, CURRENT_LOCATION
         ld a,(hl)
-        pop hl
-
-        ; Get the description of the object in DE, but leaving
-        ; HL pointing to the start of the item's entry.
-        push hl
-        ld de, ITEM_TABLE_DESCRIPTION_OFFSET
-        add hl,de
-        ld e, (hl)
-        inc hl
-        ld d, (hl)
-        pop hl
-
-        ; Get the location of the object in C, but leaving
-        ; HL pointing to the start of the item's entry.
-        push hl
-        push de
-        ld de, ITEM_TABLE_LOCATION_OFFSET
-        add hl,de
-        ld c, (hl)
-        pop de
-        pop hl
 
         ; Is the item in the room?
         cp c
         jr nz, item_not_present_loop
 
+        ; Get the description of the object in HL.
+        ld l, (IX+ITEM_TABLE_DESCRIPTION_OFFSET)
+        ld h, (IX+ITEM_TABLE_DESCRIPTION_OFFSET+1)
+
         ; OK we have an item present.  Is the description empty?
         ; if so that's a hidden object and it doesn't count.
-        ld a, d
-        or e
+        ld a, h
+        or l
         jr z, item_not_present_loop
 
         xor a
         ret
 item_not_present_loop:
-        ; Since we have HL pointing to an entry we can move to the next
-        ; just by adding the length of the table-item.
-        push de
-        ld de, ITEM_ENTRY_LENGTH
-        add hl,de
-        pop de
+        ; Move to the next entry
+        add IX,DE
         djnz look_item_loop_test
         ld a, 0xff
         ret
@@ -958,24 +940,18 @@ death_by_grue_grue:
 ; Return "A == FF" if not.
 ;
 player_has_objects:
-        ; Point to the item-table, and get the count of objects
-        ld hl, items
+        ; Point to the item-table, and prepare to loop over the items
+        ld IX, items
+        ld DE, ITEM_ENTRY_LENGTH
         ld b, ITEM_COUNT
 
 player_has_objects_loop:
 
-        ; Get the location of the object in A, but leaving
-        ; HL pointing to the start of the item's entry.
-        push hl
-        push de
-        ld de, ITEM_TABLE_LOCATION_OFFSET
-        add hl,de
-        ld a, (hl)
-        pop de
-        pop hl
+        ; Get the location of the object in A.
+        ld a,(IX+ITEM_TABLE_LOCATION_OFFSET)
 
-        ; If the location is 0xff then the player is carrying
-        ; something.
+        ; If the location is the player's posession we're carrying something,
+        ; it doesn't matter what.
         cp ITEM_CARRIED
         jr nz, player_not_carrying_loop
 
@@ -984,12 +960,8 @@ player_has_objects_loop:
         ret
 player_not_carrying_loop:
 
-        ; Since we have HL pointing to an entry we can move to the next
-        ; just by adding the length of the table-item.
-        push de
-        ld de, ITEM_ENTRY_LENGTH
-        add hl,de
-        pop de
+        ; Point to the next entry.
+        add IX, DE
 
         ; Loop again
         djnz player_has_objects_loop
@@ -1271,16 +1243,13 @@ examine_object:
         ret
 
 examine_found_it:
-        ; HL points to the start of the entry
-        ; get the pointer to the custom examine-function, in DE,
-        ; leave HL alone
-        push hl
-        ld de, ITEM_TABLE_EXAMINE_OFFSET
-        add hl,de
-        ld e, (hl)
-        inc hl
-        ld d, (hl)
-        pop hl
+
+        ; IX points to the start of the entry for the object.
+        ;
+        ; Find the name of the custom examine-handler, if any, using
+        ; the index-register.
+        ld e,(IX+ITEM_TABLE_EXAMINE_OFFSET)
+        ld d,(IX+ITEM_TABLE_EXAMINE_OFFSET+1)
 
         ; If the custom examine function is non-empty call
         ; it and return, otherwise show the extended message
@@ -1512,7 +1481,11 @@ get_found_it_take:
 
 
 
-
+;
+; Make trapdoor visible is called when the rug is taken/examined.
+;
+; It moves the trapdoor into the appropriate location within the
+; map.
 make_trapdoor_visible:
         ld hl, item_11_name
         call get_item_by_name
@@ -1524,9 +1497,11 @@ make_trapdoor_visible:
         ret
 
 place_trapdoor:
-        ; HL points to the start of the trapdoor's item-entry
-        ; change the location of that item to be the current location
-
+        ; We set the location of the trapdoor to being the
+        ; current location.
+        ;
+        ; NOTE: We could just hardcode this to location "3".
+        ;
         ; Get the current location.
         push hl
         ld hl, CURRENT_LOCATION
@@ -1534,14 +1509,7 @@ place_trapdoor:
         pop hl
 
         ; Save the location in the item.
-        push hl
-        push de
-        ld de, ITEM_TABLE_LOCATION_OFFSET
-        add hl,de
-        ld (hl), a
-        pop de
-        pop hl
-
+        ld (IX+ITEM_TABLE_LOCATION_OFFSET),a
         ret
 
 
@@ -1596,6 +1564,8 @@ help_skip_this:
 
 ;
 ; Command-handler INVENTORY
+;
+; TODO: Use index-register
 ;
 inventory_function:
         call player_has_objects         ; is the player carrying:
@@ -1670,6 +1640,8 @@ inv_item_not_carried:
 ;   LOOK AT XXX
 ;
 ; If we see "LOOK AT XXX" then we replace the command with "EXAMINE YYYY"
+;
+; TODO: Use index-register
 ;
 look_function:
 
@@ -2041,10 +2013,9 @@ sleep_function:
 
        ld de, SLEEP_START_MSG
        call bios_output_string
-
        call show_dots
 
-       ; Double the turn-count.
+       ; Double the turn-count.  (Cruel!)
        ld hl,TURN_COUNT
        ld a, (hl)
        add a, a
@@ -2090,26 +2061,24 @@ use_object:
         ; store object in HL
         call input_second_term
 
+        ; find the object
         call get_item_by_name
         cp 0
         jp z, use_found_object
 
+        ; the object was not found
         ld de, item_not_present_msg
         call bios_output_string
         ret
 
 use_found_object:
-        ; HL points to the start of the entry
-        ; get the location of the use-pointer
-        push de
-        ld de, ITEM_TABLE_USE_OFFSET
-        add hl, de
-        pop de
 
-        ; Get the drop-handler
-        ld e, (hl)
-        inc hl
-        ld d, (hl)
+        ; IX points to the start of the entry for the object.
+        ;
+        ; Find the name of the custom use-handler, if any, using
+        ; the index-register.
+        ld e, (IX+ITEM_TABLE_USE_OFFSET)
+        ld d, (IX+ITEM_TABLE_USE_OFFSET+1)
 
         ; is the use-handler empty?
         ld a, d
@@ -2163,7 +2132,7 @@ up_on_middle_floor:
         pop hl
 
         ; Are we carrying the item?
-        cp 255
+        cp ITEM_CARRIED
         jr nz, up_on_ground_floor
 
         ; We're on the middle-floor, going up, carrying the meteor.
@@ -2192,7 +2161,6 @@ up_on_basement_floor:
         dec (hl)
         call look_function
         ret
-
 
 
 show_newline:
@@ -2236,37 +2204,25 @@ drop_mirror_fn:
         ld hl, item_1_name
         call get_item_by_name
 
-        ; The item-table entry will be stored in HL.
+        ; Once we've found the item IX will point to the
+        ; entry (as well as HL).
         ;
         ; Change the location to be something random.
-        push hl
-        push de
-        ld de, ITEM_TABLE_LOCATION_OFFSET
-        add hl,de
-        ld (hl), 0x55
-        pop de
-        pop hl
+        ld (IX + ITEM_TABLE_LOCATION_OFFSET), 0xFF
 
         ; find the broken-mirror
         ld hl,item_2_name
         call get_item_by_name
 
         ; Get the current location in A
-        push hl
         ld hl, CURRENT_LOCATION
         ld a,(hl)
-        pop hl
 
-        ; The item-table entry will be stored in HL.
+        ; Once we've found the item IX will point to the
+        ; entry (as well as HL).
         ;
-        ; Change the location of the broken-mirror to be the current one
-        push hl
-        push de
-        ld de, ITEM_TABLE_LOCATION_OFFSET
-        add hl,de
-        ld (hl), a
-        pop de
-        pop hl
+        ; Change the location to be the current one.
+        ld (IX + ITEM_TABLE_LOCATION_OFFSET), a
 
         ; Show the drop message
         ld de, MIRROR_DROP_FUN
@@ -2287,6 +2243,7 @@ examine_room_fn:
 ;
 ;  If the rug is in your posession just show the description
 ;
+; TODO: Use the index register
 examine_rug_fn:
 
         ; Get the rug object
@@ -2335,6 +2292,7 @@ rug_on_ground:
 ;
 ;  Otherwise you just see the desk
 ;
+; TODO: Use index-register
 examine_desk_fn:
 
         ; Get the meteor item
@@ -2381,6 +2339,7 @@ meteor_hidden:
 ;
 ;  This is set by examine desk
 ;
+; TODO: Use index-register
 take_meteor_fn:
         ; Get the meteor item
         ld hl, item_13_name
@@ -2422,6 +2381,7 @@ take_meteor:
 ;
 ;  - AND you're in the basement
 ;
+; TODO: Use index-register
 take_rug_fn:
 
         ; Get the rug object
@@ -2494,20 +2454,14 @@ get_rug_show_inv:
 use_book_fn:
 
         call show_newline
+
         ; find the book
         ld hl, item_8_name
         call get_item_by_name
 
-        ; get the location of the extended-description pointer
-        push de
-        ld de, ITEM_TABLE_EXT_DESCRIPTION_OFFSET
-        add hl, de
-        pop de
-
-        ; Get the pointer to the string
-        ld e,(hl)
-        inc hl
-        ld d,(hl)
+        ; Get the extended description
+        ld e,(IX+ITEM_TABLE_EXT_DESCRIPTION_OFFSET)
+        ld d,(IX+ITEM_TABLE_EXT_DESCRIPTION_OFFSET+1)
 
         ; show it
         call bios_output_string
@@ -2531,12 +2485,9 @@ use_torch_fn:
         ret
 use_torch_found_t:
 
-        ; The item-table entry will be stored in HL.
-        ;
+        ; The item-table entry will be stored in HL and IX
         ; Get the state in A
-        ld de, ITEM_TABLE_STATE_OFFSET
-        add hl,de
-        ld a, (hl)
+        ld a, (IX+ITEM_TABLE_STATE_OFFSET)
 
         cp TORCH_STATE_UNLIT
         jr z, torch_was_off
@@ -2549,7 +2500,7 @@ use_torch_found_t:
 
 torch_was_off:
         ; update state
-        ld (hl), TORCH_STATE_LIT
+        ld (IX+ITEM_TABLE_STATE_OFFSET), TORCH_STATE_LIT
 
         ; update the description
         ld hl, torch_item_desc
@@ -2589,7 +2540,7 @@ out_of_here:
 
 torch_was_on:
         ; update state
-        ld (hl), TORCH_STATE_UNLIT
+        ld (IX+ITEM_TABLE_STATE_OFFSET), TORCH_STATE_UNLIT
 
         ; update the description
         ld hl, torch_item_desc
@@ -2621,11 +2572,9 @@ use_trapdoor_fn:
         call get_item_by_name
 
         ; get the state offset
-        ld de, ITEM_TABLE_STATE_OFFSET
-        add hl,de
+        ld a,(IX+ITEM_TABLE_STATE_OFFSET)
 
         ; update the state to be open
-        ld a, (hl)
         cp TRAPDOOR_STATE_CLOSED
         jr z, trapdoor_was_closed
         cp TRAPDOOR_STATE_OPEN
@@ -2638,7 +2587,7 @@ use_trapdoor_fn:
 
 trapdoor_was_closed:
         ; change the state
-        ld (hl), TRAPDOOR_STATE_OPEN
+        ld (IX+ITEM_TABLE_STATE_OFFSET), TRAPDOOR_STATE_OPEN
 
         ; update the description
         ld hl, trapdoor_desc
@@ -2659,7 +2608,7 @@ trapdoor_was_closed:
 
 trapdoor_was_open:
         ; change the state
-        ld (hl), TRAPDOOR_STATE_CLOSED
+        ld (IX+ITEM_TABLE_STATE_OFFSET), TRAPDOOR_STATE_CLOSED
 
         ; update the description
         ld hl, trapdoor_desc
@@ -3530,7 +3479,7 @@ trapdoor_edesc:
         DEFB 0,0             ; No extended description
         DEFB 0,0             ; Custom take function
         DEFB 0,0             ; No drop function
-        DEFB 0,0             ; No use function
+        DEFB 0,0             ; No custom examine function
         DEFB 0,0             ; No use function
         DEFB 0               ; item state
         DEFB 0               ; this item cannot be picked up


### PR DESCRIPTION
Use an index-register for accessing the item-table.
    
This pull-request updates our coding to use the IX register to access the items found by name.  This makes getting/setting location/state/etc simpler.
    
Since our item-table contains entries which all have the same length we can take an item like so:
    
            ld (IX+ITEM_TABLE_LOCATION_OFFSET),ITEM_CARRIED
    
Instead of the following (where previously HL contained the item's table-entry):
    
            push hl
            push de
            ld de, ITEM_TABLE_LOCATION_OFFSET
            add hl,de
            ld (hl), ITEM_CARRIED
            pop de
            pop hl
    
There is still more work to be done here, but once complete this pull-request will a) save bytes and b) close #29.
