### PR TITLE
Allow turning the torch off.

### DIFF
--- a/game.z80
+++ b/game.z80
@@ -2485,7 +2485,6 @@ torch_was_on:
         ; show the message
         ld de, TORCH_OFF_MSG
         call bios_output_string
-        pop hl
         ret
 
 


### PR DESCRIPTION
We had accidentally left a `pop hl` instruction in-place as
part of our state-update.  That meant turning the torch off
popped off the correct return-address, and gave us undefined
behaviour.

This closes #34.