### PR TITLE
Ensure that the first code executed is our decryption routine

### DIFF
--- a/game.z80
+++ b/game.z80
@@ -143,9 +143,6 @@ MACRO POP_ALL
         ;
         ORG ENTRYPOINT
 
-        ; Call system-specific setup routine before we do anything else.
-        call bios_init
-
         ;
         ; Our game can be compiled with optional "encryption", which uses
         ; a simple scheme to hide the strings in our binary.
@@ -180,6 +177,10 @@ enc_loop:
         ENC: DB "SKX"
 enc_end:
 ENDIF
+
+        ; Call system-specific setup routine before we do anything else.
+        call bios_init
+
 
         ; Here we're going to copy our game-state to the end of RAM
         ;


### PR DESCRIPTION
This pull-request closes #37, by making sure the first code we run in our binary is our decryption code (if that is enabled).

Previously we ran some code:

        call foo
        [decrypt code]
        [start of encrypted code]
        foo:
        [end of encrypted code]

If we called a routine that was after the decryption code we'd be running gibberish.  This seemed to work by accident in some systems, but was obviously broken.