### PR TITLE
Correctly terminate the game cleanly on death/quit

### DIFF
--- a/game.z80
+++ b/game.z80
@@ -668,9 +668,10 @@ play_again_yes:
 
 ; User chose "N" to "play again?"
 play_again_no:
-        ld de, play_again_no
+        ld de, play_again_no_msg
         call bios_output_string
 IF SPECTRUM
+        pop de
         ret
 ELSE
         ld c, 0x0


### PR DESCRIPTION
Previously the code would print some random gibberish and exit in an unclean fashion after the user declined the opportunity to play again.

looking at this closely it was because I used the wrong offset of the "quitting" message to print - so random binary junk would get displayed before a $ character was encountered by chance, and terminated the display.

Correctly point to the "terminating" message, and exit cleanly to BASIC/CP/M, which closes #44.